### PR TITLE
Fixes and changes towards 01-revision

### DIFF
--- a/draft-uni-qsckeys.html
+++ b/draft-uni-qsckeys.html
@@ -6,9 +6,9 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>Quantum Safe Cryptography Key Information</title>
 <meta content="Christine van Vredendaal" name="author">
-<meta content="Silvio Dragione" name="author">
+<meta content="Silvio Dragone" name="author">
 <meta content="Basil Hess" name="author">
-<meta content="Tamas Visgrady" name="author">
+<meta content="Tamas Visegrady" name="author">
 <meta content="Michael Osborne" name="author">
 <meta content="Dieter Bong" name="author">
 <meta content="Joppe Bos" name="author">
@@ -19,23 +19,23 @@
     " name="description">
 <meta content="xml2rfc 3.9.1" name="generator">
 <meta content="template" name="keyword">
-<meta content="draft-uni-qsckeys-00" name="ietf.draft">
+<meta content="draft-uni-qsckeys-01" name="ietf.draft">
 <!-- Generator version information:
   xml2rfc 3.9.1
-    Python 3.9.7
+    Python 3.9.10
     appdirs 1.4.4
-    ConfigArgParse 1.5.1
+    ConfigArgParse 1.5.2
     google-i18n-address 2.5.0
     html5lib 1.1
     intervaltree 3.1.0
-    Jinja2 2.11.3
+    Jinja2 2.11.2
     kitchen 1.2.6
     lxml 4.6.3
     pycountry 20.7.3
     pyflakes 2.3.1
-    PyYAML 5.4.1
+    PyYAML 5.4
     requests 2.26.0
-    setuptools 57.4.0
+    setuptools 60.5.0
     six 1.16.0
 -->
 <link href="draft-uni-qsckeys.xml" rel="alternate" type="application/rfc+xml">
@@ -1187,11 +1187,11 @@ li > p:last-of-type {
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">QSC Cryptography Key Information</td>
-<td class="right">November 2021</td>
+<td class="right">March 2022</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Vredendaal, et al.</td>
-<td class="center">Expires 13 May 2022</td>
+<td class="center">Expires 22 September 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1201,15 +1201,15 @@ li > p:last-of-type {
 <dt class="label-workgroup">Workgroup:</dt>
 <dd class="workgroup">Internet Engineering Task Force</dd>
 <dt class="label-individual-draft">Individual-Draft:</dt>
-<dd class="individual-draft">draft-uni-qsckeys-00</dd>
+<dd class="individual-draft">draft-uni-qsckeys-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-11-09" class="published">9 November 2021</time>
+<time datetime="2022-03-21" class="published">21 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-05-13">13 May 2022</time></dd>
+<dd class="expires"><time datetime="2022-09-22">22 September 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1276,7 +1276,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 13 May 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 22 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1285,7 +1285,7 @@ li > p:last-of-type {
 <a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
         </h2>
 <p id="section-boilerplate.2-1">
-            Copyright (c) 2021 IETF Trust and the persons identified as the
+            Copyright (c) 2022 IETF Trust and the persons identified as the
             document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.2-2">
             This document is subject to BCP 78 and the IETF Trust's Legal
@@ -1304,191 +1304,191 @@ li > p:last-of-type {
         <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
 <a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
         </h2>
-<nav class="toc"><ul class="ulEmpty ulBare toc compact">
-<li class="ulEmpty ulBare toc compact" id="section-toc.1-1.1">
+<nav class="toc"><ul class="ulEmpty compact ulBare toc">
+<li class="ulEmpty compact ulBare toc" id="section-toc.1-1.1">
             <p id="section-toc.1-1.1.1"><a href="#section-1" class="xref">1</a>.  <a href="#name-introduction" class="xref">Introduction</a></p>
-<ul class="compact ulBare ulEmpty toc">
-<li class="compact ulBare ulEmpty toc" id="section-toc.1-1.1.2.1">
+<ul class="ulBare ulEmpty compact toc">
+<li class="ulBare ulEmpty compact toc" id="section-toc.1-1.1.2.1">
                 <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="xref">1.1</a>.  <a href="#name-requirements-language" class="xref">Requirements Language</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.1.2.2">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.1.2.2">
                 <p id="section-toc.1-1.1.2.2.1" class="keepWithNext"><a href="#section-1.2" class="xref">1.2</a>.  <a href="#name-algorithm-identification" class="xref">Algorithm Identification</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.1.2.3">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.1.2.3">
                 <p id="section-toc.1-1.1.2.3.1" class="keepWithNext"><a href="#section-1.3" class="xref">1.3</a>.  <a href="#name-algorithm-and-algorithm-par" class="xref">Algorithm and Algorithm Parameter Object Identifier</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.2">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.2">
             <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-overview-of-pqc-algorithm-a" class="xref">Overview of PQC algorithm and parameter OIDs</a></p>
-<ul class="compact ulBare ulEmpty toc">
-<li class="compact ulBare ulEmpty toc" id="section-toc.1-1.2.2.1">
+<ul class="ulBare ulEmpty compact toc">
+<li class="ulBare ulEmpty compact toc" id="section-toc.1-1.2.2.1">
                 <p id="section-toc.1-1.2.2.1.1"><a href="#section-2.1" class="xref">2.1</a>.  <a href="#name-key-formats" class="xref">Key Formats</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.2.2.2">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.2.2.2">
                 <p id="section-toc.1-1.2.2.2.1"><a href="#section-2.2" class="xref">2.2</a>.  <a href="#name-public-key-format-based-on" class="xref">Public Key Format based on
-                    RFC5480</a></p>
+                    RFC5280</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.2.2.3">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.2.2.3">
                 <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="xref">2.3</a>.  <a href="#name-overview-of-memo-definition" class="xref">Overview of Memo Definitions - PQC Key Formats</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.3">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.3">
             <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-classic-mceliece" class="xref">Classic McEliece</a></p>
-<ul class="compact ulBare ulEmpty toc">
-<li class="compact ulBare ulEmpty toc" id="section-toc.1-1.3.2.1">
+<ul class="ulBare ulEmpty compact toc">
+<li class="ulBare ulEmpty compact toc" id="section-toc.1-1.3.2.1">
                 <p id="section-toc.1-1.3.2.1.1"><a href="#section-3.1" class="xref">3.1</a>.  <a href="#name-algorithm-parameter-identif" class="xref">Algorithm Parameter Identifiers</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.3.2.2">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.3.2.2">
                 <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="xref">3.2</a>.  <a href="#name-key-details" class="xref">Key Details</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.3.2.3">
-                <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="xref">3.3</a>.  <a href="#name-secret-key-full-encoding" class="xref">Secret Key Full Encoding</a></p>
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.3.2.3">
+                <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="xref">3.3</a>.  <a href="#name-private-key-full-encoding" class="xref">Private key Full Encoding</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.3.2.4">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.3.2.4">
                 <p id="section-toc.1-1.3.2.4.1"><a href="#section-3.4" class="xref">3.4</a>.  <a href="#name-public-key-full-encoding" class="xref">Public Key Full Encoding</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.4">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.4">
             <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-kyber" class="xref">Kyber</a></p>
-<ul class="compact ulBare ulEmpty toc">
-<li class="compact ulBare ulEmpty toc" id="section-toc.1-1.4.2.1">
+<ul class="ulBare ulEmpty compact toc">
+<li class="ulBare ulEmpty compact toc" id="section-toc.1-1.4.2.1">
                 <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-algorithm-parameter-identifi" class="xref">Algorithm Parameter Identifiers</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.4.2.2">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.4.2.2">
                 <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-key-details-2" class="xref">Key Details</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.4.2.3">
-                <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-secret-key-full-encoding-2" class="xref">Secret Key Full Encoding</a></p>
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.4.2.3">
+                <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-private-key-full-encoding-2" class="xref">Private key Full Encoding</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.4.2.4">
-                <p id="section-toc.1-1.4.2.4.1"><a href="#section-4.4" class="xref">4.4</a>.  <a href="#name-secret-key-partial-encoding" class="xref">Secret Key Partial Encoding</a></p>
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.4.2.4">
+                <p id="section-toc.1-1.4.2.4.1"><a href="#section-4.4" class="xref">4.4</a>.  <a href="#name-private-key-partial-encodin" class="xref">Private key Partial Encoding</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.4.2.5">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.4.2.5">
                 <p id="section-toc.1-1.4.2.5.1"><a href="#section-4.5" class="xref">4.5</a>.  <a href="#name-public-key-full-encoding-2" class="xref">Public Key Full Encoding</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.5">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.5">
             <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-ntru" class="xref">NTRU</a></p>
-<ul class="compact ulBare ulEmpty toc">
-<li class="compact ulBare ulEmpty toc" id="section-toc.1-1.5.2.1">
+<ul class="ulBare ulEmpty compact toc">
+<li class="ulBare ulEmpty compact toc" id="section-toc.1-1.5.2.1">
                 <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="xref">5.1</a>.  <a href="#name-algorithm-parameter-identifie" class="xref">Algorithm Parameter Identifiers</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.5.2.2">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.5.2.2">
                 <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="xref">5.2</a>.  <a href="#name-key-details-3" class="xref">Key Details</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.5.2.3">
-                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="xref">5.3</a>.  <a href="#name-secret-key-full-encoding-3" class="xref">Secret Key Full Encoding</a></p>
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.5.2.3">
+                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="xref">5.3</a>.  <a href="#name-private-key-full-encoding-3" class="xref">Private key Full Encoding</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.5.2.4">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.5.2.4">
                 <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="xref">5.4</a>.  <a href="#name-public-key-full-encoding-3" class="xref">Public Key Full Encoding</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.6">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.6">
             <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-saber" class="xref">SABER</a></p>
-<ul class="compact ulBare ulEmpty toc">
-<li class="compact ulBare ulEmpty toc" id="section-toc.1-1.6.2.1">
+<ul class="ulBare ulEmpty compact toc">
+<li class="ulBare ulEmpty compact toc" id="section-toc.1-1.6.2.1">
                 <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-algorithm-parameter-identifier" class="xref">Algorithm Parameter Identifiers</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.6.2.2">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.6.2.2">
                 <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-key-details-4" class="xref">Key Details</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.6.2.3">
-                <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="xref">6.3</a>.  <a href="#name-secret-key-full-encoding-4" class="xref">Secret Key Full Encoding</a></p>
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.6.2.3">
+                <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="xref">6.3</a>.  <a href="#name-private-key-full-encoding-4" class="xref">Private key Full Encoding</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.6.2.4">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.6.2.4">
                 <p id="section-toc.1-1.6.2.4.1"><a href="#section-6.4" class="xref">6.4</a>.  <a href="#name-public-key-full-encoding-4" class="xref">Public Key Full Encoding</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.7">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.7">
             <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-crystals-dilithium" class="xref">CRYSTALS-DILITHIUM</a></p>
-<ul class="compact ulBare ulEmpty toc">
-<li class="compact ulBare ulEmpty toc" id="section-toc.1-1.7.2.1">
+<ul class="ulBare ulEmpty compact toc">
+<li class="ulBare ulEmpty compact toc" id="section-toc.1-1.7.2.1">
                 <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="xref">7.1</a>.  <a href="#name-algorithm-parameter-identifiers" class="xref">Algorithm Parameter Identifiers</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.7.2.2">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.7.2.2">
                 <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="xref">7.2</a>.  <a href="#name-key-details-5" class="xref">Key Details</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.7.2.3">
-                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="xref">7.3</a>.  <a href="#name-secret-key-full-encoding-5" class="xref">Secret Key Full Encoding</a></p>
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.7.2.3">
+                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="xref">7.3</a>.  <a href="#name-private-key-full-encoding-5" class="xref">Private key Full Encoding</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.7.2.4">
-                <p id="section-toc.1-1.7.2.4.1"><a href="#section-7.4" class="xref">7.4</a>.  <a href="#name-secret-key-partial-encoding-" class="xref">Secret Key Partial Encoding Option 1</a></p>
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.7.2.4">
+                <p id="section-toc.1-1.7.2.4.1"><a href="#section-7.4" class="xref">7.4</a>.  <a href="#name-private-key-partial-encoding" class="xref">Private key Partial Encoding Option 1</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.7.2.5">
-                <p id="section-toc.1-1.7.2.5.1"><a href="#section-7.5" class="xref">7.5</a>.  <a href="#name-secret-key-partial-encoding-o" class="xref">Secret Key Partial Encoding Option 2</a></p>
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.7.2.5">
+                <p id="section-toc.1-1.7.2.5.1"><a href="#section-7.5" class="xref">7.5</a>.  <a href="#name-private-key-partial-encoding-" class="xref">Private key Partial Encoding Option 2</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.7.2.6">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.7.2.6">
                 <p id="section-toc.1-1.7.2.6.1"><a href="#section-7.6" class="xref">7.6</a>.  <a href="#name-public-key-full-encoding-5" class="xref">Public Key Full Encoding</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.8">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.8">
             <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-falcon" class="xref">FALCON</a></p>
-<ul class="compact ulBare ulEmpty toc">
-<li class="compact ulBare ulEmpty toc" id="section-toc.1-1.8.2.1">
+<ul class="ulBare ulEmpty compact toc">
+<li class="ulBare ulEmpty compact toc" id="section-toc.1-1.8.2.1">
                 <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="xref">8.1</a>.  <a href="#name-algorithm-parameter-identifiers-2" class="xref">Algorithm Parameter Identifiers</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.8.2.2">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.8.2.2">
                 <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="xref">8.2</a>.  <a href="#name-key-details-6" class="xref">Key Details</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.8.2.3">
-                <p id="section-toc.1-1.8.2.3.1"><a href="#section-8.3" class="xref">8.3</a>.  <a href="#name-secret-key-full-encoding-6" class="xref">Secret Key Full Encoding</a></p>
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.8.2.3">
+                <p id="section-toc.1-1.8.2.3.1"><a href="#section-8.3" class="xref">8.3</a>.  <a href="#name-private-key-full-encoding-6" class="xref">Private key Full Encoding</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.8.2.4">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.8.2.4">
                 <p id="section-toc.1-1.8.2.4.1"><a href="#section-8.4" class="xref">8.4</a>.  <a href="#name-public-key-full-encoding-6" class="xref">Public Key Full Encoding</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.9">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.9">
             <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-rainbow" class="xref">Rainbow</a></p>
-<ul class="compact ulBare ulEmpty toc">
-<li class="compact ulBare ulEmpty toc" id="section-toc.1-1.9.2.1">
+<ul class="ulBare ulEmpty compact toc">
+<li class="ulBare ulEmpty compact toc" id="section-toc.1-1.9.2.1">
                 <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="xref">9.1</a>.  <a href="#name-algorithm-parameter-identifiers-3" class="xref">Algorithm Parameter Identifiers</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.9.2.2">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.9.2.2">
                 <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="xref">9.2</a>.  <a href="#name-key-details-7" class="xref">Key Details</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.9.2.3">
-                <p id="section-toc.1-1.9.2.3.1"><a href="#section-9.3" class="xref">9.3</a>.  <a href="#name-secret-key-full-encoding-7" class="xref">Secret Key Full Encoding</a></p>
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.9.2.3">
+                <p id="section-toc.1-1.9.2.3.1"><a href="#section-9.3" class="xref">9.3</a>.  <a href="#name-private-key-full-encoding-7" class="xref">Private key Full Encoding</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.9.2.4">
-                <p id="section-toc.1-1.9.2.4.1"><a href="#section-9.4" class="xref">9.4</a>.  <a href="#name-secret-key-partial-encoding-2" class="xref">Secret Key Partial Encoding</a></p>
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.9.2.4">
+                <p id="section-toc.1-1.9.2.4.1"><a href="#section-9.4" class="xref">9.4</a>.  <a href="#name-private-key-partial-encoding-2" class="xref">Private key Partial Encoding</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.9.2.5">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.9.2.5">
                 <p id="section-toc.1-1.9.2.5.1"><a href="#section-9.5" class="xref">9.5</a>.  <a href="#name-public-key-full-encoding-7" class="xref">Public Key Full Encoding</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.10">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.10">
             <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.11">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.11">
             <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.12">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.12">
             <p id="section-toc.1-1.12.1"><a href="#section-12" class="xref">12</a>. <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.13">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.13">
             <p id="section-toc.1-1.13.1"><a href="#section-13" class="xref">13</a>. <a href="#name-references" class="xref">References</a></p>
-<ul class="compact ulBare ulEmpty toc">
-<li class="compact ulBare ulEmpty toc" id="section-toc.1-1.13.2.1">
+<ul class="ulBare ulEmpty compact toc">
+<li class="ulBare ulEmpty compact toc" id="section-toc.1-1.13.2.1">
                 <p id="section-toc.1-1.13.2.1.1"><a href="#section-13.1" class="xref">13.1</a>.  <a href="#name-normative-references" class="xref">Normative References</a></p>
 </li>
-              <li class="compact ulBare ulEmpty toc" id="section-toc.1-1.13.2.2">
+              <li class="ulBare ulEmpty compact toc" id="section-toc.1-1.13.2.2">
                 <p id="section-toc.1-1.13.2.2.1"><a href="#section-13.2" class="xref">13.2</a>.  <a href="#name-informative-references" class="xref">Informative References</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.14">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.14">
             <p id="section-toc.1-1.14.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-additional-stuff" class="xref">Additional Stuff</a></p>
 </li>
-          <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.15">
+          <li class="ulEmpty compact ulBare toc" id="section-toc.1-1.15">
             <p id="section-toc.1-1.15.1"><a href="#appendix-B" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
@@ -1542,9 +1542,9 @@ li > p:last-of-type {
 <div class="artwork art-text alignLeft" id="section-1.3-2">
 <pre>
 
-AlgorithmIdentifier  ::=  SEQUENCE  {
-algorithm  OBJECT IDENTIFIER, - OID: algorithm and algo parameter
-parameters pqcAlgorithmParameterName OPTIONAL
+AlgorithmIdentifier ::=  SEQUENCE {
+    algorithm  OBJECT IDENTIFIER, - OID: algorithm and algo parameter
+    parameters pqcAlgorithmParameterName OPTIONAL
 }
 pqcAlgorithmParameterName ::= PrintableString
 
@@ -1575,32 +1575,32 @@ pqcAlgorithmParameterName ::= PrintableString
 | kyber-512-r3                                                  |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-kem-kyber kyber-512-r3 }           |
-|         |dot. | 1.3.6.1.4.1.2.267.8.2.2                       |
+|         |dot. |                                               |
 |---------+-----+-----------------------------------------------|
 | kyber-512-90s-r3                                              |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-kem-kyber kyber-512-90s-r3}        |
-|         |dot  | 1.3.6.1.4.1.2.267.10.2.2                      |
+|         |dot  |                                               |
 |---------------+-----+-----------------------------------------|
 | kyber-768-r3                                                  |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-kem-kyber kyber-768-r3 }           |
-|         |dot  | 1.3.6.1.4.1.2.267.8.3.3                       |
+|         |dot  |                                               |
 |---------------+-----+-----------------------------------------|
 | kyber-768-90s-r3                                              |
 |---------------+-----+-----------------------------------------|
 |         |ASN.1| {..*.. pqc-kem-kyber kyber-768-90s-r3 }       |
-|         |dot  | 1.3.6.1.4.1.2.267.10.3.3                      |
+|         |dot  |                                               |
 |---------+-----+-----------------------------------------------|
 | kyber-1024-r3                                                 |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-kem-kyber kyber-1024-r3 }          |
-|         |dot  | 1.3.6.1.4.1.2.267.8.4.4                       |
+|         |dot  |                                               |
 |---------+-----+-----------------------------------------------|
 | kyber-1024-90s-r3                                             |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-kem-kyber kyber-1024-90s-r3}       |
-|         |dot  | 1.3.6.1.4.1.2.267.10.4.4                      |
+|         |dot  |                                               |
 |=========+=====+===============================================|
 | NTRU (PQC KEM)                                                |
 |=========+=====+===============================================|
@@ -1636,7 +1636,7 @@ pqcAlgorithmParameterName ::= PrintableString
 | dilithium-4x4-r3                                              |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1|{..*.. pqc-ds-dilithium dilithium-4x4-r3}      |
-|         |dot  | 1.3.6.1.4.1.2.267.7.4.4                       |
+|         |dot  |                                               |
 |---------------+-----+-----------------------------------------|
 | dilithium-4x4-aes-r3                                          |
 |---------+-----+-----------------------------------------------|
@@ -1646,7 +1646,7 @@ pqcAlgorithmParameterName ::= PrintableString
 | dilithium-6x5-r3                                              |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-ds-dilithium dilithium-6x5-r3}     |
-|         | Dot | 1.3.6.1.4.1.2.267.7.6.5                       |
+|         | Dot |                                               |
 |---------+-----+-----------------------------------------------|
 | dilithium-6x5-aes-r3                                          |
 |---------+-----+-----------------------------------------------|
@@ -1656,7 +1656,7 @@ pqcAlgorithmParameterName ::= PrintableString
 | dilithium-8x7-r3                                              |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-ds-dilithium dilithium-8x7-r3}     |
-|         |Dot  | 1.3.6.1.4.1.2.267.7.8.7                       |
+|         |Dot  |                                               |
 |---------+-----+-----------------------------------------------|
 | dilithium-8x7-aes-r3                                          |
 |---------+-----+-----------------------------------------------|
@@ -1692,7 +1692,7 @@ pqcAlgorithmParameterName ::= PrintableString
 <a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-key-formats" class="section-name selfRef">Key Formats</a>
         </h3>
 <p id="section-2.1-1">
-                    The Secret Key Format defined is from PKCS#8
+                    The private key format defined is from PKCS#8
                     <span>[<a href="#RFC5208" class="xref">RFC5208</a>]</span>
                     .
                     PKCS#8 PrivateKeyInfo is defined as:<a href="#section-2.1-1" class="pilcrow">¶</a></p>
@@ -1713,13 +1713,13 @@ PrivateKeyInfo ::=  SEQUENCE {
 <section id="section-2.2">
         <h3 id="name-public-key-format-based-on">
 <a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-public-key-format-based-on" class="section-name selfRef">Public Key Format based on
-                    <em class="xref">[RFC5480]</em></a>
+                    <em class="xref">[RFC5280]</em></a>
         </h3>
-<p id="section-2.2-1">RFC5480 subjectPublicKeyInfo is defined in as:<a href="#section-2.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.2-1">RFC5280 subjectPublicKeyInfo is defined in as:<a href="#section-2.2-1" class="pilcrow">¶</a></p>
 <div class="artwork art-text alignLeft" id="section-2.2-2">
 <pre>
 
-subjectPublicKeyInfo := SEQUENCE {
+SubjectPublicKeyInfo := SEQUENCE {
     algorithm          AlgorithmIdentifier  -- see chapter above
     subjectPublicKey   BIT STRING           -- see chapter below
 }
@@ -1892,32 +1892,35 @@ subjectPublicKeyInfo := SEQUENCE {
         <h3 id="name-key-details">
 <a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-key-details" class="section-name selfRef">Key Details</a>
         </h3>
-<p id="section-3.2-1">Public key. The public-key consists of 
-            * T: mt x k matrix
-            Each row of T is represented as a ceiling(k/8)-byte string, and the public key is represented as the mt*ceiling(k/8)-byte concatenation of these strings.
-            Secret key. The secret key consists of five parameters:<a href="#section-3.2-1" class="pilcrow">¶</a></p>
+<p id="section-3.2-1">Public key. The public-key consists of<a href="#section-3.2-1" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-3.2-2.1">delta: nonce<a href="#section-3.2-2.1" class="pilcrow">¶</a>
-</li>
-          <li class="compact" id="section-3.2-2.2">C    : column selections<a href="#section-3.2-2.2" class="pilcrow">¶</a>
-</li>
-          <li class="compact" id="section-3.2-2.3">g    : monic irreducible polynomial<a href="#section-3.2-2.3" class="pilcrow">¶</a>
-</li>
-          <li class="compact" id="section-3.2-2.4">alpha: field orderings<a href="#section-3.2-2.4" class="pilcrow">¶</a>
-</li>
-          <li class="compact" id="section-3.2-2.5">s    : uniform random n-bit string<a href="#section-3.2-2.5" class="pilcrow">¶</a>
+<li class="compact" id="section-3.2-2.1">T: mt x k matrix<a href="#section-3.2-2.1" class="pilcrow">¶</a>
 </li>
         </ul>
-<p id="section-3.2-3">The size necessary to hold all secret key elements accounts to ceiling(l / 8) + [ceiling(nu / 8) | 8] + ceiling(m / 8) + ceiling((2*m - 1) * 2*m - 4) + ceiling(n / 8) bytes.
-            The resulting public key and private key sizes can be found in the table below.<a href="#section-3.2-3" class="pilcrow">¶</a></p>
+<p id="section-3.2-3">Each row of T is represented as a ceiling(k/8)-byte string, and the public key is represented as the mt*ceiling(k/8)-byte concatenation of these strings.
+            Private key. The private key consists of five parameters:<a href="#section-3.2-3" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-3.2-4.1">delta: nonce<a href="#section-3.2-4.1" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-3.2-4.2">C    : column selections<a href="#section-3.2-4.2" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-3.2-4.3">g    : monic irreducible polynomial<a href="#section-3.2-4.3" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-3.2-4.4">alpha: field orderings<a href="#section-3.2-4.4" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-3.2-4.5">s    : uniform random n-bit string<a href="#section-3.2-4.5" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-3.2-5">The size necessary to hold all private key elements accounts to ceiling(l / 8) + [ceiling(nu / 8) | 8] + ceiling(m / 8) + ceiling((2*m - 1) * 2*m - 4) + ceiling(n / 8) bytes.
+            The resulting public key and private key sizes can be found in the table below.<a href="#section-3.2-5" class="pilcrow">¶</a></p>
 <div id="McElieceKeySizes">
 <figure id="figure-3">
-          <div class="artwork art-text alignLeft" id="section-3.2-4.1">
+          <div class="artwork art-text alignLeft" id="section-3.2-6.1">
 <pre>
 
 |=====================+=================+================|
 | Parameter Set.      | Size of the     | Size of the    |
-|                     | public key      | secret key     |
+|                     | public key      | private key    |
 |                     | in bytes.       | in bytes       |
 |=====================+=================+================|
 | mceliece348864-r3   |       261120    |       6492     |
@@ -1938,8 +1941,8 @@ subjectPublicKeyInfo := SEQUENCE {
 </div>
 </section>
 <section id="section-3.3">
-        <h3 id="name-secret-key-full-encoding">
-<a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-secret-key-full-encoding" class="section-name selfRef">Secret Key Full Encoding</a>
+        <h3 id="name-private-key-full-encoding">
+<a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-private-key-full-encoding" class="section-name selfRef">Private key Full Encoding</a>
         </h3>
 <p id="section-3.3-1">Distributing a Classic McEliece private key with PKCS#8 involves including:<a href="#section-3.3-1" class="pilcrow">¶</a></p>
 <ul class="compact">
@@ -1954,13 +1957,13 @@ subjectPublicKeyInfo := SEQUENCE {
 <pre>
 
 McEliecePrivateKey ::= SEQUENCE {
-    Version    INTEGER {v0(0)} -- version (round 3)
+    version    INTEGER {v0(0)} -- version (round 3)
     delta      OCTET STRING,   -- nonce
     C          OCTET STRING,   -- column selections
     g          OCTET STRING,   -- monic irreducible polynomial
     alpha      OCTET STRING,   -- field orderings
     s          OCTET STRING,   -- random n-bit string
-    PublicKey  [0] IMPLICIT McEliecePublicKey OPTIONAL
+    publicKey  [0] IMPLICIT McEliecePublicKey OPTIONAL
                                 -- see next section
 }
 
@@ -1974,8 +1977,7 @@ McEliecePrivateKey ::= SEQUENCE {
 <div class="artwork art-text alignLeft" id="section-3.4-1">
 <pre>
 
-Classic McEliece Public Key Format
-    McEliecePublicKey ::= SEQUENCE {
+McEliecePublicKey ::= SEQUENCE {
     T       OCTET STRING    -- public key
 }
 
@@ -2010,8 +2012,8 @@ Classic McEliece Public Key Format
 | Parameters              | n= 256,                             |
 |                         | k=2                                 |
 |                         | q=3329                              |
-|                         | nu_1=3                              |
-|                         | nu_2=2                              |
+|                         | eta_1=3                             |
+|                         | eta_2=2                             |
 |                         | (d_u, d_v)=(10, 4)                  |
 |                         | delta=2^{-139}                      |
 |=========================+=====================================|
@@ -2024,8 +2026,8 @@ Classic McEliece Public Key Format
 | Parameters              | n= 256,                             |
 |                         | k=2                                 |
 |                         | q=3329                              |
-|                         | nu_1=3                              |
-|                         | nu_2=2                              |
+|                         | eta_1=3                             |
+|                         | eta_2=2                             |
 |                         | (d_u, d_v)=(10, 4)                  |
 |                         | delta=2^{-139}                      |
 |=========================+=====================================|
@@ -2038,8 +2040,8 @@ Classic McEliece Public Key Format
 | Parameters              | n= 256,                             |
 |                         | k=3                                 |
 |                         | q=3329                              |
-|                         | nu_1=2                              |
-|                         | nu_2=2                              |
+|                         | eta_1=2                             |
+|                         | eta_2=2                             |
 |                         | (d_u, d_v)=(10, 4)                  |
 |                         | delta=2^{-164}                      |
 |=========================+=====================================|
@@ -2052,8 +2054,8 @@ Classic McEliece Public Key Format
 | Parameters              | n= 256,                             |
 |                         | k=3                                 |
 |                         | q=3329                              |
-|                         | nu_1=2                              |
-|                         | nu_2=2                              |
+|                         | eta_1=2                             |
+|                         | eta_2=2                             |
 |                         | (d_u, d_v)=(10, 4)                  |
 |                         | delta=2^{-164}                      |
 |=========================+=====================================|
@@ -2066,8 +2068,8 @@ Classic McEliece Public Key Format
 | Parameters              | n= 256,                             |
 |                         | k=4                                 |
 |                         | q=3329                              |
-|                         | nu_1=2                              |
-|                         | nu_2=2                              |
+|                         | eta_1=2                             |
+|                         | eta_2=2                             |
 |                         | (d_u, d_v)=(11, 5)                  |
 |                         | delta=2^{-174}                      |
 |=========================+=====================================|
@@ -2080,8 +2082,8 @@ Classic McEliece Public Key Format
 | Parameters              | n= 256,                             |
 |                         | k=4                                 |
 |                         | q=3329                              |
-|                         | nu_1=2                              |
-|                         | nu_2=2                              |
+|                         | eta_1=2                             |
+|                         | eta_2=2                             |
 |                         | (d_u, d_v)=(11, 5)                  |
 |                         | delta=2^{-174}                      |
 |=========================+=====================================|
@@ -2106,36 +2108,36 @@ Classic McEliece Public Key Format
         </ul>
 <p id="section-4.2-3">The size necessary to hold all public key elements is 12*k*n/8+32 bytes.
                     
-                    Secret key. The secret key consists of 3 parameters:<a href="#section-4.2-3" class="pilcrow">¶</a></p>
+                    Private key. The private key consists of 3 parameters:<a href="#section-4.2-3" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-4.2-4.1">s: encoded sample from a centered binomial distribution B_nu1 (12*k*n/8 bytes)<a href="#section-4.2-4.1" class="pilcrow">¶</a>
+<li class="compact" id="section-4.2-4.1">s: encoded sample from a centered binomial distribution B_{eta_1} (12*k*n/8 bytes)<a href="#section-4.2-4.1" class="pilcrow">¶</a>
 </li>
-          <li class="compact" id="section-4.2-4.2">z: a nonce (32 bytes)<a href="#section-4.2-4.2" class="pilcrow">¶</a>
+          <li class="compact" id="section-4.2-4.2">H(pk): hashed public key (32 bytes). Kyber uses SHA3-256 as H by default. The '90s' variants use SHA256 instead.<a href="#section-4.2-4.2" class="pilcrow">¶</a>
 </li>
-          <li class="compact" id="section-4.2-4.3">H(pk): hashed public key (32 bytes). Kyber uses SHA3-256 as H by default. The '90s' variants use SHA256 instead.<a href="#section-4.2-4.3" class="pilcrow">¶</a>
+          <li class="compact" id="section-4.2-4.3">z: a nonce (32 bytes)<a href="#section-4.2-4.3" class="pilcrow">¶</a>
 </li>
         </ul>
-<p id="section-4.2-5">If the secret key is fully populated, it consists of 3 parameters. The size necessary to hold all secret key elements accounts to 12*k*n/8+64 bytes, not counting the optional public key.
+<p id="section-4.2-5">If the private key is fully populated, it consists of 3 parameters. The size necessary to hold all private key elements accounts to 12*k*n/8+64 bytes, not counting the optional public key.
                     The resulting public key and private key sizes are shown in the following table.<a href="#section-4.2-5" class="pilcrow">¶</a></p>
 <div id="KyberKeyLengths">
 <figure id="figure-5">
           <div class="artwork art-text alignLeft" id="section-4.2-6.1">
 <pre>
 
-|==========================+=========+==========+=========|
-| Algorithm OID            | Public  |   Secret |  Secret |
-|                          | Key     |   Key    |  Key    |
-|                          |         |          |(partial)|
-|==========================+=========+==========+=========|
-| kyber512-r3 /            |   800   |   832    |    32   |
-| kyber512-90s-r3          |         |          |         |
-|--------------------------|---------|----------|---------|
-| kyber768-r3 /            |  1184   |   1216   |    32   |
-| kyber768-90s-r3          |         |          |         |
-|--------------------------|--------------------|---------|
-| kyber1024-r3 /           |  1568   |   1600   |    32   |
-| kyber1024-90s-r3         |         |          |         |
-|==========================+=========+==========+=========|
+|==========================+=========+==========+===========|
+| Algorithm OID            | Public  |   Private |  Private |
+|                          | Key     |   Key    |  Key      |
+|                          |         |          |(partial)  |
+|==========================+=========+==========+===========|
+| kyber512-r3 /            |   800   |   832    |    32     |
+| kyber512-90s-r3          |         |          |           |
+|--------------------------|---------|----------|-----------|
+| kyber768-r3 /            |  1184   |   1216   |    32     |
+| kyber768-90s-r3          |         |          |           |
+|--------------------------|--------------------|-----------|
+| kyber1024-r3 /           |  1568   |   1600   |    32     |
+| kyber1024-90s-r3         |         |          |           |
+|==========================+=========+==========+===========|
 
 </pre>
 </div>
@@ -2143,8 +2145,8 @@ Classic McEliece Public Key Format
 </div>
 </section>
 <section id="section-4.3">
-        <h3 id="name-secret-key-full-encoding-2">
-<a href="#section-4.3" class="section-number selfRef">4.3. </a><a href="#name-secret-key-full-encoding-2" class="section-name selfRef">Secret Key Full Encoding</a>
+        <h3 id="name-private-key-full-encoding-2">
+<a href="#section-4.3" class="section-number selfRef">4.3. </a><a href="#name-private-key-full-encoding-2" class="section-name selfRef">Private key Full Encoding</a>
         </h3>
 <p id="section-4.3-1">Distributing a Kyber private key with PKCS#8 requires:<a href="#section-4.3-1" class="pilcrow">¶</a></p>
 <ul class="compact">
@@ -2159,20 +2161,20 @@ Classic McEliece Public Key Format
 <pre>
 
 KyberPrivateKey ::= SEQUENCE {
-    Version     INTEGER {v0(0)}   -- version (round 3)
-    nonce       OCTET STRING,     -- z
+    version     INTEGER {v0(0)}   -- version (round 3)
     s           OCTET STRING,     -- sample s
-    PublicKey   [0] IMPLICIT KyberPublicKey OPTIONAL,
+    publicKey   [0] IMPLICIT KyberPublicKey OPTIONAL,
                                   -- see next section
     hpk         OCTET STRING      -- H(pk)
+    nonce       OCTET STRING,     -- z
 }
 
 </pre><a href="#section-4.3-4" class="pilcrow">¶</a>
 </div>
 </section>
 <section id="section-4.4">
-        <h3 id="name-secret-key-partial-encoding">
-<a href="#section-4.4" class="section-number selfRef">4.4. </a><a href="#name-secret-key-partial-encoding" class="section-name selfRef">Secret Key Partial Encoding</a>
+        <h3 id="name-private-key-partial-encodin">
+<a href="#section-4.4" class="section-number selfRef">4.4. </a><a href="#name-private-key-partial-encodin" class="section-name selfRef">Private key Partial Encoding</a>
         </h3>
 <p id="section-4.4-1">The partially populated parameter set uses of the fact that some parameters can be regenerated. In this case, only the initial seed 'd' (nonce) is stored and used to regenerate the full key.  
                     Partially encoded keys use the same ASN.1 structure as the fully polulated keys, simply with the regenerated fields set to EMPTY. 
@@ -2184,11 +2186,11 @@ KyberPrivateKey ::= SEQUENCE {
 
 KyberPrivateKey ::= SEQUENCE {
     version     INTEGER {v0(0)}   -- version (round 3)
-    nonce       OCTET STRING,     -- d
     s           OCTET STRING,     -- EMPTY
-    PublicKey   [0] IMPLICIT KyberPublicKey OPTIONAL,
+    publicKey   [0] IMPLICIT KyberPublicKey OPTIONAL,
                                   -- see next section
     hpk         OCTET STRING      -- EMPTY
+    nonce       OCTET STRING,     -- d
 }
 
 </pre><a href="#section-4.4-2" class="pilcrow">¶</a>
@@ -2236,10 +2238,10 @@ KyberPublicKey ::= SEQUENCE {
 | NIST Level Security     | Level 1                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Dimension/Degree n= 509             |
-|                         | Polynomial  Phin= (xn - 1)/(x-1     |
+|                         | Polynomial  Phin=(x^n - 1)/(x-1)    |
 |                         | Polynomial  Phi1=(x-1)              |
 |                         | Modulus p=3                         |
-|                         | Modulus q= 2048                     |
+|                         | Modulus q=2048                      |
 |=========================+=====================================|
 | ntruhps2048677-r3                                             |
 |=========================+=====================================|
@@ -2247,11 +2249,11 @@ KyberPublicKey ::= SEQUENCE {
 |                         | &lt;.  &gt;                               |
 | NIST Level Security     | Level 3 (1) see spec.               |
 |-------------------------|-------------------------------------|
-| Parameters              | Dimension/Degree n= 677             |
-|                         | Polynomial  Phin= (xn - 1)/(x-1)    |
+| Parameters              | Dimension/Degree n=677              |
+|                         | Polynomial  Phin=(x^n - 1)/(x-1)    |
 |                         | Polynomial  Phi1=(x-1)              |
 |                         | Modulus p=3                         |
-|                         | Modulus q= 2048                     |
+|                         | Modulus q=2048                      |
 |=========================+=====================================|
 | ntruhps4096821-r3                                             |
 |=========================+=====================================|
@@ -2260,7 +2262,7 @@ KyberPublicKey ::= SEQUENCE {
 | NIST Level Security     | Level 3 (1) see spec.               |
 |-------------------------|-------------------------------------|
 | Parameters              | Dimension/Degree n= 821             |
-|                         | Polynomial  Phin= (xn - 1)/(x-1)    |
+|                         | Polynomial  Phin=(x^n - 1)/(x-1)    |
 |                         | Polynomial  Phi1=(x-1)              |
 |                         | Modulus p=3                         |
 |                         | Modulus q= 4096                     |
@@ -2272,10 +2274,10 @@ KyberPublicKey ::= SEQUENCE {
 | NIST Level Security     | Level 5 (3)  see spec.              |
 |-------------------------|-------------------------------------|
 | Parameters              | Dimension/Degree n= 701             |
-|                         | Polynomial  Phin= (xn - 1)/(x-1)    |
+|                         | Polynomial  Phin= (x^n - 1)/(x-1)   |
 |                         | Polynomial  Phi1=(x-1)              |
 |                         | Modulus p=3                         |
-|                         | Modulus q= 8192                     |
+|                         | Modulus q=8192                      |
 |=========================+=====================================|
 
 </pre>
@@ -2290,33 +2292,33 @@ KyberPublicKey ::= SEQUENCE {
         </h3>
 <p id="section-5.2-1">Public key. The public-key consists of a single parameter :<a href="#section-5.2-1" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-5.2-2.1">a polynomial h that satisfies h?f=3?g in the ring Rq=Z[x]/(q, Phi1?Phin).<a href="#section-5.2-2.1" class="pilcrow">¶</a>
+<li class="compact" id="section-5.2-2.1">a polynomial h that satisfies h*f=3*g in the ring Rq=Z[x]/(q, Phi_1*Phi_n).<a href="#section-5.2-2.1" class="pilcrow">¶</a>
 </li>
         </ul>
-<p id="section-5.2-3">This means there are n - 1 coefficients of size at most q in the public key, and the size necessary to store the polynomial is therefore is ceiling((n - 1)?log2(q)/8) bytes. The resulting sizes for the parameter sets can be found in the Table below.
-                    Secret key. The secret key consists of 4 parameters:<a href="#section-5.2-3" class="pilcrow">¶</a></p>
+<p id="section-5.2-3">This means there are n - 1 coefficients of size at most q in the public key, and the size necessary to store the polynomial is therefore is ceiling((n - 1)*log2(q)/8) bytes. The resulting sizes for the parameter sets can be found in the Table below.
+                    Private key. The private key consists of 4 parameters:<a href="#section-5.2-3" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-5.2-4.1">a polynomial f that is a ternary (coefficients fi are in {-1, 0, 1}) polynomial of degree n - 2, with the additional property that &amp;#8721;_(i=0)^(n-3)  f_i?? f?_(i+1)&amp;#8805;0,<a href="#section-5.2-4.1" class="pilcrow">¶</a>
+<li class="compact" id="section-5.2-4.1">a polynomial f that is a ternary (coefficients fi are in {-1, 0, 1}) polynomial of degree n - 2, with the additional property that &amp;#8721;_(i=0)^{n-3}  f_i*f_{i+1}&amp;#8805;0,<a href="#section-5.2-4.1" class="pilcrow">¶</a>
 </li>
-          <li class="compact" id="section-5.2-4.2">a polynomial fp that satisfies f?fp=1 in the ring Rq=Z[x]/(3, Phin),<a href="#section-5.2-4.2" class="pilcrow">¶</a>
+          <li class="compact" id="section-5.2-4.2">a polynomial f_p that satisfies f*f_p=1 in the ring Rq=Z[x]/(3, Phi_n),<a href="#section-5.2-4.2" class="pilcrow">¶</a>
 </li>
-          <li class="compact" id="section-5.2-4.3">a polynomial hq that satisfies h?hq=1 in the ring Rq=Z[x]/(q, Phin), and<a href="#section-5.2-4.3" class="pilcrow">¶</a>
+          <li class="compact" id="section-5.2-4.3">a polynomial h_q that satisfies h*h_q=1 in the ring Rq=Z[x]/(q, Phi_n), and<a href="#section-5.2-4.3" class="pilcrow">¶</a>
 </li>
           <li class="compact" id="section-5.2-4.4">a seed=fg_bits || prf_key=f_bits ||  g_bits || prf_key containing the randomness for the key sampling and the implicit rejection mechanism. Optionally implementers may expand this from a 32-byte seed.<a href="#section-5.2-4.4" class="pilcrow">¶</a>
 </li>
         </ul>
-<p id="section-5.2-5">This means there are 2 polynomials, f and fp, having n - 1 coefficients with absolute value at most 1 in the secret key. For these polynomials, the packing algorithm in Section 1.8.7 of the Specification allows to pack 5 coefficients in a byte, so the storage requirement to store each is ceiling((n - 1)/5) bytes. Additionally hq is part of the secret key, which requires the same storage size as that of the public key h, i.e. ceiling((n - 1)?log2(q)/8) bytes. For the seed bytes, the specification recommends:<a href="#section-5.2-5" class="pilcrow">¶</a></p>
+<p id="section-5.2-5">This means there are 2 polynomials, f and fp, having n - 1 coefficients with absolute value at most 1 in the private key. For these polynomials, the packing algorithm in Section 1.8.7 of the Specification allows to pack 5 coefficients in a byte, so the storage requirement to store each is ceiling((n - 1)/5) bytes. Additionally hq is part of the private key, which requires the same storage size as that of the public key h, i.e. ceiling((n - 1)*log2(q)/8) bytes. For the seed bytes, the specification recommends:<a href="#section-5.2-5" class="pilcrow">¶</a></p>
 <ul class="compact">
 <li class="compact" id="section-5.2-6.1">&gt;f_bits having n - 1 bytes,<a href="#section-5.2-6.1" class="pilcrow">¶</a>
 </li>
-          <li class="compact" id="section-5.2-6.2">&gt;g_bits having n - 1 bytes for ntruhrss701, ceiling(30/8?(n-1)) bytes for the other parameter sets,<a href="#section-5.2-6.2" class="pilcrow">¶</a>
+          <li class="compact" id="section-5.2-6.2">&gt;g_bits having n - 1 bytes for ntruhrss701, ceiling(30/8*(n-1)) bytes for the other parameter sets,<a href="#section-5.2-6.2" class="pilcrow">¶</a>
 </li>
           <li class="compact" id="section-5.2-6.3">prf_key having 32 bytes.<a href="#section-5.2-6.3" class="pilcrow">¶</a>
 </li>
         </ul>
 <p id="section-5.2-7">Implementers may choose to expand the seed from one 32-byte seed.
                     The resulting sizes for the parameter sets can be found in the Table below. Where the seed expansion is omitted, the 32-byte seed must be replaced by key_seed_bits=sample_key_bits+prf_key_bits. The impact of these options are indicated as 32-byte seed/expanded seed in the Table below.
-                    Parameter Set    Size of the public key in bytes    Size of the secret key in bytes<a href="#section-5.2-7" class="pilcrow">¶</a></p>
+                    Parameter Set    Size of the public key in bytes    Size of the private key in bytes<a href="#section-5.2-7" class="pilcrow">¶</a></p>
 <div id="NTRUOIDs">
 <figure id="figure-7">
           <div class="artwork art-text alignLeft" id="section-5.2-8.1">
@@ -2327,31 +2329,31 @@ KyberPublicKey ::= SEQUENCE {
 |---------------------|------------------------------|
 | Public Key (Bytes)  | 699                          |
 | seed/expanded seed  | 935 / 3348                   |
-| f,fp,hq,seed        | 102,102,699,32/2445          |
+| f,f_p,h_q,seed      | 102,102,699,32/2445          |
 |=====================+==============================|
 | ntruhps2048677-r3                                  |
 |---------------------|------------------------------|
 | Public Key (Bytes)  | 699                          |
 | seed/expanded seed  | 935 / 3348                   |
-| f,fp,hq,seed        | 102,102,699,32/2445          |
+| f,f_p,h_q,seed      | 102,102,699,32/2445          |
 |=====================+==============================|
 | ntruhps2048677-r3                                  |
 |---------------------|------------------------------|
-| Public Key (Bytes)  |    930                          |
+| Public Key (Bytes)  |    930                       |
 | seed/expanded seed  | 1234 / 4445                  |
-| (f,fp,hq,seed)      | 136,136,930,32/3243          |
+| (f,f_p,h_q,seed)    | 136,136,930,32/3243          |
 |=====================+==============================|
 | ntruhps4096821-r3                                  |
 |---------------------|------------------------------|
 | Public Key (Bytes)  | 1230                         |
 | seed/expanded seed  | 1590 / 5485                  |
-| (f,fp,hq,seed)      | 164,164,1230,32/3927         |
+| (f,f_p,h_q,seed)    | 164,164,1230,32/3927         |
 |=====================+==============================|
 | ntruhrss701-r3                                     |
 |---------------------|------------------------------|
 | Public Key (Bytes)  | 1138                         |
 | seed/expanded seed  | 1450 / 2850                  |
-| (f,fp,hq,seed)      | 140,140,1138,32/1432         |
+| (f,f_p,h_q,seed)    | 140,140,1138,32/1432         |
 |=====================+==============================|
 
 </pre>
@@ -2360,8 +2362,8 @@ KyberPublicKey ::= SEQUENCE {
 </div>
 </section>
 <section id="section-5.3">
-        <h3 id="name-secret-key-full-encoding-3">
-<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-secret-key-full-encoding-3" class="section-name selfRef">Secret Key Full Encoding</a>
+        <h3 id="name-private-key-full-encoding-3">
+<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-private-key-full-encoding-3" class="section-name selfRef">Private key Full Encoding</a>
         </h3>
 <p id="section-5.3-1">An NTRU private key encoded according with PKCS#8 MUST include the following two fields:<a href="#section-5.3-1" class="pilcrow">¶</a></p>
 <ul class="compact">
@@ -2371,7 +2373,7 @@ KyberPublicKey ::= SEQUENCE {
 </li>
         </ul>
 <p id="section-5.3-3">When a NTRU public key is included in the distributed PrivateKeyInfo, the PublicKey field in NTRUPrivateKey is used (see description of NTRUPublicKey below).
-                    An NTRU secret key contains f, fp and hq, as well as a seed. The octet string format indicates the length of the string to follow, and indicates whether the seed or expanded seed is used.<a href="#section-5.3-3" class="pilcrow">¶</a></p>
+                    An NTRU private key contains f, f_p and h_q, as well as a seed. The octet string format indicates the length of the string to follow, and indicates whether the seed or expanded seed is used.<a href="#section-5.3-3" class="pilcrow">¶</a></p>
 <div class="artwork art-text alignLeft" id="section-5.3-4">
 <pre>
 
@@ -2381,7 +2383,7 @@ NTRUPrivateKey ::= SEQUENCE {
     fp         OCTET STRING,      -- short integer polynomial gp
     hq         OCTET STRING,      -- mod q integer polynomial hq
     seed       OCTET STRING,      -- fg_bits/prf_bits (or their seed)
-    PublicKey [0] IMPLICIT NTRUPublicKey OPTIONAL -- see next section
+    publicKey [0] IMPLICIT NTRUPublicKey OPTIONAL -- see next section
 }
 
 </pre><a href="#section-5.3-4" class="pilcrow">¶</a>
@@ -2391,7 +2393,7 @@ NTRUPrivateKey ::= SEQUENCE {
         <h3 id="name-public-key-full-encoding-3">
 <a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-public-key-full-encoding-3" class="section-name selfRef">Public Key Full Encoding</a>
         </h3>
-<p id="section-5.4-1">From the NTRU specification, the public key contains h. Each coefficient of h is encoded as an ? bit sequence, where ?=ceiling((n - 1)?log2(q)). Coefficients are then concatenated (two's complement, big endian convention). The final bit string is zero padded to fit into a byte sequence.
+<p id="section-5.4-1">From the NTRU specification, the public key contains h. Each coefficient of h is encoded as an l bit sequence, where l=ceiling((n - 1)*log2(q)). Coefficients are then concatenated (two's complement, big endian convention). The final bit string is zero padded to fit into a byte sequence.
                     NTRUPublicKey := SEQUENCE {
                     h          OCTET STRING  -- integer polynomial h
                     }<a href="#section-5.4-1" class="pilcrow">¶</a></p>
@@ -2422,7 +2424,7 @@ NTRUPrivateKey ::= SEQUENCE {
 | NIST Level Security     | Level 1                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Degree n= 256                       |
-|                         | rank of the module ?= 2             |
+|                         | rank of the module l=2              |
 |                         | binomial distribution with u=10     |
 |                         | Modulus q=2^{13} and p=2^{10}       |
 |=========================+=====================================|
@@ -2433,7 +2435,7 @@ NTRUPrivateKey ::= SEQUENCE {
 | NIST Level Security     | Level 3                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Degree n= 256                       |
-|                         | rank of the module ?= 3             |
+|                         | rank of the module l=3              |
 |                         | binomial distribution with u=8      |
 |                         | Modulus q=2^{13} and p=2^{10}       |
 |=========================+=====================================|
@@ -2444,7 +2446,7 @@ NTRUPrivateKey ::= SEQUENCE {
 | NIST Level Security     | Level 5                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Degree n= 256                       |
-|                         | rank of the module ?= 4             |
+|                         | rank of the module l=4              |
 |                         | binomial distribution with u=6      |
 |                         | Modulus q=2^{13} and p=2^{10}       |
 |=========================+=====================================|
@@ -2453,7 +2455,7 @@ NTRUPrivateKey ::= SEQUENCE {
 </div>
 <figcaption><a href="#figure-8" class="selfRef">Figure 8</a></figcaption></figure>
 </div>
-<p id="section-6.1-3">The rank of the module is denoted ? and differs per parameter set.<a href="#section-6.1-3" class="pilcrow">¶</a></p>
+<p id="section-6.1-3">The rank of the module is denoted l and differs per parameter set.<a href="#section-6.1-3" class="pilcrow">¶</a></p>
 </section>
 <section id="section-6.2">
         <h3 id="name-key-details-4">
@@ -2466,31 +2468,31 @@ NTRUPrivateKey ::= SEQUENCE {
           <li class="compact" id="section-6.2-2.2">polynomials of degree 256 with 10-bit integer coefficients denoted by vector b.<a href="#section-6.2-2.2" class="pilcrow">¶</a>
 </li>
         </ul>
-<p id="section-6.2-3">This means the size of the public key can be stored using ?*256*10+256 bits. The size of the public key as used in the three parameter sets can be found in the Table below.<a href="#section-6.2-3" class="pilcrow">¶</a></p>
-<p id="section-6.2-4">Secret key. The secret key s consists of three parameters:<a href="#section-6.2-4" class="pilcrow">¶</a></p>
+<p id="section-6.2-3">This means the size of the public key can be stored using l*256*10+256 bits. The size of the public key as used in the three parameter sets can be found in the Table below.<a href="#section-6.2-3" class="pilcrow">¶</a></p>
+<p id="section-6.2-4">Private key. The private key s consists of three parameters:<a href="#section-6.2-4" class="pilcrow">¶</a></p>
 <ul class="compact">
 <li class="compact" id="section-6.2-5.1">a 256-bit uniform random value z<a href="#section-6.2-5.1" class="pilcrow">¶</a>
 </li>
-          <li class="compact" id="section-6.2-5.2"> ? polynomials of degree 256 with 13-bit integer coefficients denoted by s<a href="#section-6.2-5.2" class="pilcrow">¶</a>
+          <li class="compact" id="section-6.2-5.2">l polynomials of degree 256 with 13-bit integer coefficients denoted by s<a href="#section-6.2-5.2" class="pilcrow">¶</a>
 </li>
           <li class="compact" id="section-6.2-5.3">H(pk): hashed public key (32 bytes)<a href="#section-6.2-5.3" class="pilcrow">¶</a>
 </li>
         </ul>
-<p id="section-6.2-6">This means the secret key can be stored using 512+?*256*13 bits. The size of the secret key as used in the three parameter sets can be found in the Table below.<a href="#section-6.2-6" class="pilcrow">¶</a></p>
+<p id="section-6.2-6">This means the private key can be stored using 512+l*256*13 bits. The size of the private key as used in the three parameter sets can be found in the Table below.<a href="#section-6.2-6" class="pilcrow">¶</a></p>
 <div id="SABERKeySizes">
 <figure id="figure-9">
           <div class="artwork art-text alignLeft" id="section-6.2-7.1">
 <pre>
 
-|==========================+=========+==========|
-| Algorithm                | Public  |   Secret |
-|                          | Key     |   Key    |
-|                          | Length  |   Length |
-|==========================+=========+==========+
-| LightSaber-r3            |    672  |    896   |
-| Saber-r3                 |    992  |   1312   |
-| FireSaber-r3             |   1312  |   1728   |
-|==========================+=========+==========|
+|==========================+=========+===========|
+| Algorithm                | Public  |   Private |
+|                          | Key     |   Key     |
+|                          | Length  |   Length  |
+|==========================+=========+===========+
+| LightSaber-r3            |    672  |    896    |
+| Saber-r3                 |    992  |   1312    |
+| FireSaber-r3             |   1312  |   1728    |
+|==========================+=========+===========|
 
 </pre>
 </div>
@@ -2498,8 +2500,8 @@ NTRUPrivateKey ::= SEQUENCE {
 </div>
 </section>
 <section id="section-6.3">
-        <h3 id="name-secret-key-full-encoding-4">
-<a href="#section-6.3" class="section-number selfRef">6.3. </a><a href="#name-secret-key-full-encoding-4" class="section-name selfRef">Secret Key Full Encoding</a>
+        <h3 id="name-private-key-full-encoding-4">
+<a href="#section-6.3" class="section-number selfRef">6.3. </a><a href="#name-private-key-full-encoding-4" class="section-name selfRef">Private key Full Encoding</a>
         </h3>
 <p id="section-6.3-1">A SABER private key encoded according with PKCS#8 MUST include the following two fields:<a href="#section-6.3-1" class="pilcrow">¶</a></p>
 <ul class="compact">
@@ -2516,7 +2518,7 @@ SABERPrivateKey ::= SEQUENCE {
     version     INTEGER  {v0(0)}    -- version (round 3)
     z           OCTET STRING,       -- 32-byte random value z
     s           OCTET STRING,       -- short integer polynomial s
-    PublicKey   [0] IMPLICIT SABERPublicKey OPTIONAL,
+    publicKey   [0] IMPLICIT SABERPublicKey OPTIONAL,
                                     -- see next section
     hpk         OCTET STRING        -- H(pk)
 }
@@ -2545,8 +2547,8 @@ SABERPublicKey := SEQUENCE {
 <a href="#section-7" class="section-number selfRef">7. </a><a href="#name-crystals-dilithium" class="section-name selfRef">CRYSTALS-DILITHIUM</a>
       </h2>
 <p id="section-7-1">Dilithium is a digital signature scheme that is based on the hardness of lattice problems over module lattices.
-                Project Website:    https://pq-crystals.org/dilithium/index.shtml
-                NIST Round 3 Submission (version 3.1):    https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+                Project Website: https://pq-crystals.org/dilithium/index.shtml
+                NIST Round 3 Submission (version 3.1): https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
                 https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf<a href="#section-7-1" class="pilcrow">¶</a></p>
 <section id="section-7.1">
         <h3 id="name-algorithm-parameter-identifiers">
@@ -2565,8 +2567,8 @@ SABERPublicKey := SEQUENCE {
 |                         | 1.3.6.1.4.1.2.267.7.4.4             |
 | NIST Level Security     | Level 2                             |
 |-------------------------|-------------------------------------|
-| Parameters              | Polynomial Ring Zq[x]/( x^n +1)     |
-|                         | Dimension/Degree n= 256             |
+| Parameters              | Polynomial Ring Zq[x]/( x^n+1 )     |
+|                         | Dimension/Degree n=256              |
 |                         | Modulus q=8380417                   |
 |                         | Dropped bits from t: d=13           |
 |                         | # of +-1's in c: tau=39             |
@@ -2574,7 +2576,7 @@ SABERPublicKey := SEQUENCE {
 |                         | gamma coefficient range: gamma1=2^17|
 |                         | low-order rounding range: gamma2=(q-|
 |                         | 1)/88                               |
-|                         | Secret Key Range (nu)=2             |
+|                         | Private key Range eta=2             |
 |                         | Dimensions of A: (k,l)=(4,4)        |
 |                         | Max # of 1's in the hint h: w=80    |
 |                         | Repetitions=4.25                    |
@@ -2586,7 +2588,7 @@ SABERPublicKey := SEQUENCE {
 | NIST Level Security     | Level 2                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
-|                         | Dimension/Degree n= 256             |
+|                         | Dimension/Degree n=256              |
 |                         | Modulus q=8380417                   |
 |                         | Dropped bits from t: d=13           |
 |                         | # of +-1's in c: tau=39             |
@@ -2594,7 +2596,7 @@ SABERPublicKey := SEQUENCE {
 |                         | y coefficient range: gamma1=2^17    |
 |                         | low-order rounding range:gamma2=(q- |
 |                         | -1)/88                              |
-|                         | Secret Key Range (nu)=2             |
+|                         | Private key Range eta=2             |
 |                         | Dimensions of A: (k,l)=(4,4)        |
 |                         | Max # of 1's in the hint h: w=80    |
 |                         | Repetitions=4.25                    |
@@ -2606,15 +2608,15 @@ SABERPublicKey := SEQUENCE {
 | NIST Level Security     | Level 3                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
-|                         | Dimension/Degree n= 256             |
+|                         | Dimension/Degree n=256              |
 |                         | Modulus q=8380417                   |
 |                         | Dropped bits from t: d=13           |
-|                         | # of +-1's in c: ?=49               |
+|                         | # of +-1's in c: tau=49             |
 |                         | challenge entropy=225               |
 |                         | y coefficient range: gamma1=2^19    |
 |                         | low-order rounding range:gamma2=(q- |
 |                         | -1)/32                              |
-|                         | Secret Key Range (nu)=4             |
+|                         | Private key Range eta=4             |
 |                         | Dimensions of A: (k,l)=(6,5)        |
 |                         | Max # of 1's in the hint h: w=55    |
 |                         | Repetitions=5.1                     |
@@ -2626,7 +2628,7 @@ SABERPublicKey := SEQUENCE {
 | NIST Level Security     | Level 3                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Polynomial Ring Zq[x]/( x^n +1 )    |
-|                         | Dimension/Degree n= 256             |
+|                         | Dimension/Degree n=256              |
 |                         | Modulus q=8380417                   |
 |                         | Dropped bits from t: d=13           |
 |                         | # of +-1's in c: tau=49             |
@@ -2634,7 +2636,7 @@ SABERPublicKey := SEQUENCE {
 |                         | y coefficient range: gamma1=2^19    |
 |                         | low-order rounding range:gamma2=(q- |
 |                         | -1)/32                              |
-|                         | Secret Key Range (nu)=4             |
+|                         | Private key Range eta=4             |
 |                         | Dimensions of A: (k,l)=(6,5)        |
 |                         | Max # of 1's in the hint h: w=55    |
 |                         | Repetitions=5.1                     |
@@ -2646,15 +2648,15 @@ SABERPublicKey := SEQUENCE {
 | NIST Level Security     | Level 5                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
-|                         | Dimension/Degree n= 256             |
+|                         | Dimension/Degree n=256              |
 |                         | Modulus q=8380417                   |
 |                         | Dropped bits from t: d=13           |
 |                         | # of +-1's in c: tau=60             |
 |                         | challenge entropy=257               |
-|                         | y coefficient range: ?1=2^19        |
+|                         | y coefficient range: gamma1=2^19    |
 |                         | low-order rounding range:gamma2=(q- |
 |                         | -1)/32                              |
-|                         | Secret Key Range (nu)=2             |
+|                         | Private key Range eta=2             |
 |                         | Dimensions of A: (k,l)=(8,7)        |
 |                         | Max # of 1's in the hint h: w=75    |
 |                         | Repetitions=3.85                    |
@@ -2666,7 +2668,7 @@ SABERPublicKey := SEQUENCE {
 | NIST Level Security     | Level 5                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
-|                         | Dimension/Degree n= 256             |
+|                         | Dimension/Degree n=256              |
 |                         | Modulus q=8380417                   |
 |                         | Dropped bits from t: d=13           |
 |                         | # of +-1's in c: tau=60             |
@@ -2674,7 +2676,7 @@ SABERPublicKey := SEQUENCE {
 |                         | y coefficient range: gamma1=2^19    |
 |                         | low-order rounding range:gamma2=(q- |
 |                         | -1)/32                              |
-|                         | Secret Key Range (nu)=2             |
+|                         | Private key Range eta=2             |
 |                         | Dimensions of A: (k,l)=(8,7)        |
 |                         | Max # of 1's in the hint h: w=75    |
 |                         | Repetitions=3.85                    |
@@ -2698,7 +2700,7 @@ SABERPublicKey := SEQUENCE {
 </li>
         </ul>
 <p id="section-7.2-3">The size necessary to hold all public key elements accounts to 32+320*k bytes.<a href="#section-7.2-3" class="pilcrow">¶</a></p>
-<p id="section-7.2-4">Secret key. The secret key consists of 6 parameters:<a href="#section-7.2-4" class="pilcrow">¶</a></p>
+<p id="section-7.2-4">Private key. The private key consists of 6 parameters:<a href="#section-7.2-4" class="pilcrow">¶</a></p>
 <ul class="compact">
 <li class="compact" id="section-7.2-5.1">rho: nonce<a href="#section-7.2-5.1" class="pilcrow">¶</a>
 </li>
@@ -2713,25 +2715,25 @@ SABERPublicKey := SEQUENCE {
           <li class="compact" id="section-7.2-5.6">t0: k polynomials<a href="#section-7.2-5.6" class="pilcrow">¶</a>
 </li>
         </ul>
-<p id="section-7.2-6">If the secret key is fully populated, it consists of 6 parameters. The size necessary to hold all secret key elements accounts to 32+32+32+32*[(k+l)*ceiling(log(2*nu+1))+13*k] bytes.
+<p id="section-7.2-6">If the private key is fully populated, it consists of 6 parameters. The size necessary to hold all private key elements accounts to 32+32+32+32*[(k+l)*ceiling(log(2*eta+1))+13*k] bytes.
                     The resulting public key and private key sizes can be found in the table below.<a href="#section-7.2-6" class="pilcrow">¶</a></p>
 <div id="DilithiumKeySizes">
 <figure id="figure-11">
           <div class="artwork art-text alignLeft" id="section-7.2-7.1">
 <pre>
 
-|=========================+========+========+=========+=========|
-| Algorithm               | Public | Secret | Partial | Partial |
-|                         | Key    | Key SK | SK (V1) | SK (V2) |
-|                         | Length | Length | Length  | Length  |
-|=========================+========+========+=========+=========+
-| dilithium-4x4-r3        | 1312   | 2528   |   64    |    32   |
-| dilithium-4x4-aes-r3    | 1312   | 2528   |   64    |    32   |
-| dilithium-6x5-r3        | 1952   | 4000   |   64    |    32   |
-| dilithium-6x5-aes-r3    | 1952   | 4000   |   64    |    32   |
-| dilithium-8x7-r3        | 2596   | 4864   |   64    |    32   |
-| dilithium-8x7-aes-r3    | 2592   | 4864   |   64    |    32   |
-|=========================+========+========+=========+=========|
+|=========================+========+=========+=========+=========|
+| Algorithm               | Public | Private | Partial | Partial |
+|                         | Key    | Key SK  | SK (V1) | SK (V2) |
+|                         | Length | Length  | Length  | Length  |
+|=========================+========+=========+=========+=========+
+| dilithium-4x4-r3        | 1312   | 2528    |   64    |    32   |
+| dilithium-4x4-aes-r3    | 1312   | 2528    |   64    |    32   |
+| dilithium-6x5-r3        | 1952   | 4000    |   64    |    32   |
+| dilithium-6x5-aes-r3    | 1952   | 4000    |   64    |    32   |
+| dilithium-8x7-r3        | 2592   | 4864    |   64    |    32   |
+| dilithium-8x7-aes-r3    | 2592   | 4864    |   64    |    32   |
+|=========================+========+=========+=========+=========|
 
 </pre>
 </div>
@@ -2739,8 +2741,8 @@ SABERPublicKey := SEQUENCE {
 </div>
 </section>
 <section id="section-7.3">
-        <h3 id="name-secret-key-full-encoding-5">
-<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-secret-key-full-encoding-5" class="section-name selfRef">Secret Key Full Encoding</a>
+        <h3 id="name-private-key-full-encoding-5">
+<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-private-key-full-encoding-5" class="section-name selfRef">Private key Full Encoding</a>
         </h3>
 <p id="section-7.3-1">A Dilithium private key encoded according with PKCS#8 MUST include the following two fields:<a href="#section-7.3-1" class="pilcrow">¶</a></p>
 <ul class="compact">
@@ -2762,7 +2764,7 @@ DilithiumPrivateKey ::= SEQUENCE {
     s1          BIT STRING,         -- vector(L)
     s2          BIT STRING,         -- vector(K)
     t0          BIT STRING,
-    PublicKey  [0] IMPLICIT DilithiumPublicKey OPTIONAL
+    publicKey  [0] IMPLICIT DilithiumPublicKey OPTIONAL
                                     -- see next section
 }
 
@@ -2770,8 +2772,8 @@ DilithiumPrivateKey ::= SEQUENCE {
 </div>
 </section>
 <section id="section-7.4">
-        <h3 id="name-secret-key-partial-encoding-">
-<a href="#section-7.4" class="section-number selfRef">7.4. </a><a href="#name-secret-key-partial-encoding-" class="section-name selfRef">Secret Key Partial Encoding Option 1</a>
+        <h3 id="name-private-key-partial-encoding">
+<a href="#section-7.4" class="section-number selfRef">7.4. </a><a href="#name-private-key-partial-encoding" class="section-name selfRef">Private key Partial Encoding Option 1</a>
         </h3>
 <p id="section-7.4-1">In option 1 of Dilithium partial encoding the rho (nonce) and the seed (key) are used to regenerate the full key.
                     Note: There are a number of alternative ways to encode a partially filled structure that include defining fields as optional and defining fields as 'EMPTY'. As an example partial RSA keys are encoded using EMPTY fields. It can be argued that defining fields as EMPTY significantly simplifies the implementation of parsing ASN.1 frames.
@@ -2788,7 +2790,7 @@ DilithiumPrivateKey ::= SEQUENCE {
     s1          BIT STRING,         -- EMPTY
     s2          BIT STRING,         -- EMPTY
     t0          BIT STRING,         -- EMPTY
-    PublicKey   [0] IMPLICIT DilithiumPublicKey OPTIONAL
+    publicKey   [0] IMPLICIT DilithiumPublicKey OPTIONAL
                                     -- see next section
 }
 
@@ -2796,8 +2798,8 @@ DilithiumPrivateKey ::= SEQUENCE {
 </div>
 </section>
 <section id="section-7.5">
-        <h3 id="name-secret-key-partial-encoding-o">
-<a href="#section-7.5" class="section-number selfRef">7.5. </a><a href="#name-secret-key-partial-encoding-o" class="section-name selfRef">Secret Key Partial Encoding Option 2</a>
+        <h3 id="name-private-key-partial-encoding-">
+<a href="#section-7.5" class="section-number selfRef">7.5. </a><a href="#name-private-key-partial-encoding-" class="section-name selfRef">Private key Partial Encoding Option 2</a>
         </h3>
 <p id="section-7.5-1">In option 2 of Dilithium partial encoding only zeta (nonce) is used to regenerate the full key.
                     The ASN.1 encoding for this is defined as follows:<a href="#section-7.5-1" class="pilcrow">¶</a></p>
@@ -2812,7 +2814,7 @@ DilithiumPrivateKey ::= SEQUENCE {
     s1          BIT STRING,         -- EMPTY
     s2          BIT STRING,         -- EMPTY
     t0          BIT STRING,         -- EMPTY
-    PublicKey   [0] IMPLICIT DilithiumPublicKey OPTIONAL
+    publicKey   [0] IMPLICIT DilithiumPublicKey OPTIONAL
                                    -- see next section
 }
 
@@ -2860,13 +2862,13 @@ DilithiumPublicKey ::= SEQUENCE {
 | NIST Level Security     | Level 1                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Dimension/Degree n = 512            |
-|                         | Polynomial Phi = 1+X{n}             |
+|                         | Polynomial Phi = 1+x^n              |
 |                         | Modulus q = 12289                   |
 |                         | Max. signature square norm          |
-|                         | floor (beta2) = 34034726            |
+|                         | floor (beta^2) = 34034726           |
 |                         | Standard deviation = 165.736617183  |
-|                         | sigmamax = 1.8205                   |
-|                         | sigmamin = 1.27783369               |
+|                         | sigma_{max} = 1.8205                |
+|                         | sigma_{min} = 1.27783369            |
 |=========================+=====================================|
 | falcon1024-r3                                                 |
 |=========================+=====================================|
@@ -2875,13 +2877,13 @@ DilithiumPublicKey ::= SEQUENCE {
 | NIST Level Security     | Level 5                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Dimension/Degree n = 1024           |
-|                         | Polynomial Phi = 1+X{n}             |
+|                         | Polynomial Phi = 1+x^n              |
 |                         | Modulus q = 12289                   |
 |                         | Max. signature square norm          |
-|                         | floor (beta2) = 34034726            |
+|                         | floor (beta^2) = 34034726           |
 |                         | Standard deviation = 168.388571447  |
-|                         | sigmamax = 1.8205                   |
-|                         | sigmamin = 1.298280334              |
+|                         | sigma_{max} = 1.8205                |
+|                         | sigma_{min} = 1.298280334           |
 |=========================+=====================================|
 
 </pre>
@@ -2893,26 +2895,26 @@ DilithiumPublicKey ::= SEQUENCE {
         <h3 id="name-key-details-6">
 <a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-key-details-6" class="section-name selfRef">Key Details</a>
         </h3>
-<p id="section-8.2-1">The FALCON secret key contains the key components f, g and F.
-                    Each coefficient of f and g is encoded over a fixed number of bits, which depends on the degree of f and g: 6 bits each for degree 512 (parameter name = falcon512-r3) and 5 bits each for degree 1024 (parameter name = falcon1024-r3). Coefficients of F use 8 bits each, regardless of its degree. Each coefficient uses signed encoding, with two's complement for negative values. Moreover, the minimal value is forbidden, e.g. when using degree 512, the valid range for a coefficient of f or g is ?31 to +31; ?32 is not allowed.<a href="#section-8.2-1" class="pilcrow">¶</a></p>
-<div id="FALCONSecretKeySizes">
+<p id="section-8.2-1">The FALCON private key contains the key components f, g and F.
+                    Each coefficient of f and g is encoded over a fixed number of bits, which depends on the degree of f and g: 6 bits each for degree 512 (parameter name = falcon512-r3) and 5 bits each for degree 1024 (parameter name = falcon1024-r3). Coefficients of F use 8 bits each, regardless of its degree. Each coefficient uses signed encoding, with two's complement for negative values. Moreover, the minimal value is forbidden, e.g. when using degree 512, the valid range for a coefficient of f or g is -31 to +31; -32 is not allowed.<a href="#section-8.2-1" class="pilcrow">¶</a></p>
+<div id="FALCONPrivateKeySizes">
 <figure id="figure-13">
           <div class="artwork art-text alignLeft" id="section-8.2-2.1">
 <pre>
 
-|==========================+=========+==========|
-| Algorithm OID            | Params  |   Secret |
-|                          |         |   Key    |
-|                          |         |   Length |
-|==========================+=========+==========+
-| falcon512-r3             | f=384   | 1280     |
-|                          | g=384   |          |
-|                          | F=512   |          |
-|--------------------------+---------+----------|
-| falcon1024-r3            | f=640   | 2304     |
-|                          | g=640   |          |
-|                          | F=1024  |          |
-|==========================+=========+==========+
+|==========================+=========+===========|
+| Algorithm OID            | Params  |   Private |
+|                          |         |   Key     |
+|                          |         |   Length  |
+|==========================+=========+===========+
+| falcon512-r3             | f=384   | 1280      |
+|                          | g=384   |           |
+|                          | F=512   |           |
+|--------------------------+---------+-----------|
+| falcon1024-r3            | f=640   | 2304      |
+|                          | g=640   |           |
+|                          | F=1024  |           |
+|==========================+=========+===========+
 
 </pre>
 </div>
@@ -2920,8 +2922,8 @@ DilithiumPublicKey ::= SEQUENCE {
 </div>
 </section>
 <section id="section-8.3">
-        <h3 id="name-secret-key-full-encoding-6">
-<a href="#section-8.3" class="section-number selfRef">8.3. </a><a href="#name-secret-key-full-encoding-6" class="section-name selfRef">Secret Key Full Encoding</a>
+        <h3 id="name-private-key-full-encoding-6">
+<a href="#section-8.3" class="section-number selfRef">8.3. </a><a href="#name-private-key-full-encoding-6" class="section-name selfRef">Private key Full Encoding</a>
         </h3>
 <p id="section-8.3-1">Encoding a FALCON private key with PKCS#8 must include the following two fields:<a href="#section-8.3-1" class="pilcrow">¶</a></p>
 <ul class="compact">
@@ -2939,8 +2941,8 @@ FALCONPrivateKey ::= SEQUENCE {
     version     INTEGER {v2(1)}    -- syntax version 2 (round 3)
     f           OCTET STRING,      -- short integer polynomial f
     g           OCTET STRING,      -- short integer polynomial g
-    F           OCTET STRING,      -- short integer polynomial F
-    PublicKey   [0] IMPLICIT FALCONPublicKey  OPTIONAL
+    f           OCTET STRING,      -- short integer polynomial F
+    publicKey   [0] IMPLICIT FALCONPublicKey  OPTIONAL
                                    -- see next section
 }
 
@@ -3061,7 +3063,7 @@ FALCONPublicKey := SEQUENCE {
         </ul>
 <p id="section-9.2-3">This mapping can be expressed as m quadratic polynomials in the ring F[x1, ... , xn], which means the public key consists of m*(n+1)*(n+2)/2 elements of F. With optimizations (see Rainbow specification), this can be reduced to m*n*(n+1)/2 elements of F. The size necessary to hold all public key elements accounts to m*n*(n+1)/16*f bytes, where f=4 for rainbowI and 8 for rainbowIII and rainbowV. For all parameter sets ell is 16 bytes.
                     
-                    Secret key. The secret key consists of 4 parameters:<a href="#section-9.2-3" class="pilcrow">¶</a></p>
+                    Private key. The private key consists of 4 parameters:<a href="#section-9.2-3" class="pilcrow">¶</a></p>
 <ul class="compact">
 <li class="compact" id="section-9.2-4.1">S: affine map from F^{m} to F^{m}<a href="#section-9.2-4.1" class="pilcrow">¶</a>
 </li>
@@ -3088,7 +3090,7 @@ FALCONPublicKey := SEQUENCE {
         </ul>
 <p id="section-9.2-9">The partial public key now consists of 5 submatrices totaling o1*o2*v1 + o1*o1*(o1+1)/2 +o1*o2*o1 + o1*o2*(o2+1)/2 + o2*o2*(o2+1)/2 elements of F. 
                     Additionally the seed spub is 32 bytes.
-                    The secret key can also be stored as the seeds of the key generation process spriv (32 bytes) and spub (32 bytes). 
+                    The private key can also be stored as the seeds of the key generation process spriv (32 bytes) and spub (32 bytes). 
                     This is denoted as the compressed key and has a size of total 64 bytes. 
                     The resulting public key and private key sizes can be found in the table below.<a href="#section-9.2-9" class="pilcrow">¶</a></p>
 <div id="RainbowKeySizes">
@@ -3097,7 +3099,7 @@ FALCONPublicKey := SEQUENCE {
 <pre>
 
 |=========================+==========+=========|
-| Algorithm               | Public   | Secret  |
+| Algorithm               | Public   | Private |
 |                         | Key      | Key     |
 |                         | Length   | Length  |
 |=========================+==========+=========+
@@ -3115,8 +3117,8 @@ FALCONPublicKey := SEQUENCE {
 </div>
 </section>
 <section id="section-9.3">
-        <h3 id="name-secret-key-full-encoding-7">
-<a href="#section-9.3" class="section-number selfRef">9.3. </a><a href="#name-secret-key-full-encoding-7" class="section-name selfRef">Secret Key Full Encoding</a>
+        <h3 id="name-private-key-full-encoding-7">
+<a href="#section-9.3" class="section-number selfRef">9.3. </a><a href="#name-private-key-full-encoding-7" class="section-name selfRef">Private key Full Encoding</a>
         </h3>
 <p id="section-9.3-1">A Rainbow private key encoded according with PKCS#8 MUST include the following two fields:<a href="#section-9.3-1" class="pilcrow">¶</a></p>
 <ul class="compact">
@@ -3133,11 +3135,11 @@ FALCONPublicKey := SEQUENCE {
 
 RainbowPrivateKey ::= SEQUENCE {
     version    INTEGER {v0(0)}       -- version (round 3)
-    S          OCTET STRING,         -- map S
-    T          OCTET STRING,         -- map T
-    F          OCTET STRING,         -- map F
+    s          OCTET STRING,         -- map S
+    t          OCTET STRING,         -- map T
+    f          OCTET STRING,         -- map F
     ell        OCTET STRING,
-    PublicKey  [0] IMPLICIT RainbowPublicKey OPTIONAL
+    publicKey  [0] IMPLICIT RainbowPublicKey OPTIONAL
     -- see next section
 }
 
@@ -3145,8 +3147,8 @@ RainbowPrivateKey ::= SEQUENCE {
 </div>
 </section>
 <section id="section-9.4">
-        <h3 id="name-secret-key-partial-encoding-2">
-<a href="#section-9.4" class="section-number selfRef">9.4. </a><a href="#name-secret-key-partial-encoding-2" class="section-name selfRef">Secret Key Partial Encoding</a>
+        <h3 id="name-private-key-partial-encoding-2">
+<a href="#section-9.4" class="section-number selfRef">9.4. </a><a href="#name-private-key-partial-encoding-2" class="section-name selfRef">Private key Partial Encoding</a>
         </h3>
 <p id="section-9.4-1">A partially populated private key is used when Compressed Rainbow is used. 
                     In this case, spriv and spub are used to regenerate the full key.
@@ -3159,7 +3161,7 @@ RainbowPrivateKey ::= SEQUENCE {
     s_priv     OCTET STRING,    -- seed for private key
     s_pub      OCTET STRING,    -- seed for public key
     ell        OCTET STRING,
-    PublicKey  [0] IMPLICIT RainbowPublicKey OPTIONAL
+    publicKey  [0] IMPLICIT RainbowPublicKey OPTIONAL
                                 -- see next section
 }
 
@@ -3178,7 +3180,7 @@ RainbowPrivateKey ::= SEQUENCE {
 
 RainbowPublicKey ::= SEQUENCE {
     s_pub      OCTET STRING      -- (EMPTY)
-    P          OCTET STRING,
+    p          OCTET STRING,
     ell        OCTET STRING
 }
 
@@ -3291,7 +3293,7 @@ RainbowPublicKey ::= SEQUENCE {
 </div>
 </address>
 <address class="vcard">
-        <div dir="auto" class="left"><span class="fn nameRole">Silvio Dragione (<span class="role">editor</span>)</span></div>
+        <div dir="auto" class="left"><span class="fn nameRole">Silvio Dragone (<span class="role">editor</span>)</span></div>
 <div dir="auto" class="left"><span class="org">IBM Research GmbH</span></div>
 <div dir="auto" class="left"><span class="street-address">Saeumerstrasse 4</span></div>
 <div dir="auto" class="left">CH-<span class="postal-code">8803</span> <span class="locality">Rueschlikon</span>
@@ -3299,7 +3301,7 @@ RainbowPublicKey ::= SEQUENCE {
 <div dir="auto" class="left"><span class="country-name">Switzerland</span></div>
 <div class="email">
 <span>Email:</span>
-<a href="mailto:sdi@zurich.ibm.com" class="email">sdi@zurich.ibm.com</a>
+<a href="mailto:sid@zurich.ibm.com" class="email">sid@zurich.ibm.com</a>
 </div>
 </address>
 <address class="vcard">
@@ -3315,7 +3317,7 @@ RainbowPublicKey ::= SEQUENCE {
 </div>
 </address>
 <address class="vcard">
-        <div dir="auto" class="left"><span class="fn nameRole">Tamas Visgrady (<span class="role">editor</span>)</span></div>
+        <div dir="auto" class="left"><span class="fn nameRole">Tamas Visegrady (<span class="role">editor</span>)</span></div>
 <div dir="auto" class="left"><span class="org">IBM Research GmbH</span></div>
 <div dir="auto" class="left"><span class="street-address">Saeumerstrasse 4</span></div>
 <div dir="auto" class="left">CH-<span class="postal-code">8803</span> <span class="locality">Rueschlikon</span>

--- a/draft-uni-qsckeys.txt
+++ b/draft-uni-qsckeys.txt
@@ -5,7 +5,7 @@
 Internet Engineering Task Force                   C.v.V. Vredendaal, Ed.
 Internet-Draft                                        NXP Semiconductors
 Intended status: Informational                         S.D. Dragone, Ed.
-Expires: 13 May 2022                                      B.H. Hess, Ed.
+Expires: 22 September 2022                                B.H. Hess, Ed.
                                                      T.V. Visegrady, Ed.
                                                        M.O. Osborne, Ed.
                                                        IBM Research GmbH
@@ -13,11 +13,11 @@ Expires: 13 May 2022                                      B.H. Hess, Ed.
                                                          Utimaco IS GmbH
                                                            J.B. Bos, Ed.
                                                       NXP Semiconductors
-                                                         9 November 2021
+                                                           21 March 2022
 
 
                Quantum Safe Cryptography Key Information
-                          draft-uni-qsckeys-00
+                          draft-uni-qsckeys-01
 
 Abstract
 
@@ -46,21 +46,21 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 13 May 2022.
+   This Internet-Draft will expire on 22 September 2022.
 
 
 
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                  [Page 1]
+Vredendaal, et al.      Expires 22 September 2022               [Page 1]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
 Copyright Notice
 
-   Copyright (c) 2021 IETF Trust and the persons identified as the
+   Copyright (c) 2022 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -80,28 +80,28 @@ Table of Contents
      1.3.  Algorithm and Algorithm Parameter Object Identifier . . .   4
    2.  Overview of PQC algorithm and parameter OIDs  . . . . . . . .   5
      2.1.  Key Formats . . . . . . . . . . . . . . . . . . . . . . .   7
-     2.2.  Public Key Format based on RFC5480  . . . . . . . . . . .   8
+     2.2.  Public Key Format based on RFC5280  . . . . . . . . . . .   8
      2.3.  Overview of Memo Definitions - PQC Key Formats  . . . . .   8
    3.  Classic McEliece  . . . . . . . . . . . . . . . . . . . . . .   9
      3.1.  Algorithm Parameter Identifiers . . . . . . . . . . . . .   9
      3.2.  Key Details . . . . . . . . . . . . . . . . . . . . . . .  12
-     3.3.  Secret Key Full Encoding  . . . . . . . . . . . . . . . .  12
+     3.3.  Private key Full Encoding . . . . . . . . . . . . . . . .  12
      3.4.  Public Key Full Encoding  . . . . . . . . . . . . . . . .  13
    4.  Kyber . . . . . . . . . . . . . . . . . . . . . . . . . . . .  13
      4.1.  Algorithm Parameter Identifiers . . . . . . . . . . . . .  13
-     4.2.  Key Details . . . . . . . . . . . . . . . . . . . . . . .  15
-     4.3.  Secret Key Full Encoding  . . . . . . . . . . . . . . . .  16
-     4.4.  Secret Key Partial Encoding . . . . . . . . . . . . . . .  17
-     4.5.  Public Key Full Encoding  . . . . . . . . . . . . . . . .  17
+     4.2.  Key Details . . . . . . . . . . . . . . . . . . . . . . .  16
+     4.3.  Private key Full Encoding . . . . . . . . . . . . . . . .  17
+     4.4.  Private key Partial Encoding  . . . . . . . . . . . . . .  18
+     4.5.  Public Key Full Encoding  . . . . . . . . . . . . . . . .  18
    5.  NTRU  . . . . . . . . . . . . . . . . . . . . . . . . . . . .  18
-     5.1.  Algorithm Parameter Identifiers . . . . . . . . . . . . .  18
-     5.2.  Key Details . . . . . . . . . . . . . . . . . . . . . . .  19
-     5.3.  Secret Key Full Encoding  . . . . . . . . . . . . . . . .  21
+     5.1.  Algorithm Parameter Identifiers . . . . . . . . . . . . .  19
+     5.2.  Key Details . . . . . . . . . . . . . . . . . . . . . . .  20
+     5.3.  Private key Full Encoding . . . . . . . . . . . . . . . .  22
      5.4.  Public Key Full Encoding  . . . . . . . . . . . . . . . .  22
    6.  SABER . . . . . . . . . . . . . . . . . . . . . . . . . . . .  22
-     6.1.  Algorithm Parameter Identifiers . . . . . . . . . . . . .  22
-     6.2.  Key Details . . . . . . . . . . . . . . . . . . . . . . .  23
-     6.3.  Secret Key Full Encoding  . . . . . . . . . . . . . . . .  24
+     6.1.  Algorithm Parameter Identifiers . . . . . . . . . . . . .  23
+     6.2.  Key Details . . . . . . . . . . . . . . . . . . . . . . .  24
+     6.3.  Private key Full Encoding . . . . . . . . . . . . . . . .  24
      6.4.  Public Key Full Encoding  . . . . . . . . . . . . . . . .  25
    7.  CRYSTALS-DILITHIUM  . . . . . . . . . . . . . . . . . . . . .  25
      7.1.  Algorithm Parameter Identifiers . . . . . . . . . . . . .  25
@@ -109,25 +109,25 @@ Table of Contents
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                  [Page 2]
+Vredendaal, et al.      Expires 22 September 2022               [Page 2]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
-     7.3.  Secret Key Full Encoding  . . . . . . . . . . . . . . . .  29
-     7.4.  Secret Key Partial Encoding Option 1  . . . . . . . . . .  30
-     7.5.  Secret Key Partial Encoding Option 2  . . . . . . . . . .  30
+     7.3.  Private key Full Encoding . . . . . . . . . . . . . . . .  29
+     7.4.  Private key Partial Encoding Option 1 . . . . . . . . . .  30
+     7.5.  Private key Partial Encoding Option 2 . . . . . . . . . .  30
      7.6.  Public Key Full Encoding  . . . . . . . . . . . . . . . .  31
    8.  FALCON  . . . . . . . . . . . . . . . . . . . . . . . . . . .  31
      8.1.  Algorithm Parameter Identifiers . . . . . . . . . . . . .  31
      8.2.  Key Details . . . . . . . . . . . . . . . . . . . . . . .  32
-     8.3.  Secret Key Full Encoding  . . . . . . . . . . . . . . . .  33
+     8.3.  Private key Full Encoding . . . . . . . . . . . . . . . .  33
      8.4.  Public Key Full Encoding  . . . . . . . . . . . . . . . .  34
    9.  Rainbow . . . . . . . . . . . . . . . . . . . . . . . . . . .  34
      9.1.  Algorithm Parameter Identifiers . . . . . . . . . . . . .  34
      9.2.  Key Details . . . . . . . . . . . . . . . . . . . . . . .  36
-     9.3.  Secret Key Full Encoding  . . . . . . . . . . . . . . . .  37
-     9.4.  Secret Key Partial Encoding . . . . . . . . . . . . . . .  37
+     9.3.  Private key Full Encoding . . . . . . . . . . . . . . . .  37
+     9.4.  Private key Partial Encoding  . . . . . . . . . . . . . .  37
      9.5.  Public Key Full Encoding  . . . . . . . . . . . . . . . .  38
    10. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  38
    11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  38
@@ -165,9 +165,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                  [Page 3]
+Vredendaal, et al.      Expires 22 September 2022               [Page 3]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
 1.2.  Algorithm Identification
@@ -207,9 +207,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    pqcAlgorithmParameterName type in the optional parameters field:
 
 
-   AlgorithmIdentifier  ::=  SEQUENCE  {
-   algorithm  OBJECT IDENTIFIER, - OID: algorithm and algo parameter
-   parameters pqcAlgorithmParameterName OPTIONAL
+   AlgorithmIdentifier ::=  SEQUENCE {
+       algorithm  OBJECT IDENTIFIER, - OID: algorithm and algo parameter
+       parameters pqcAlgorithmParameterName OPTIONAL
    }
    pqcAlgorithmParameterName ::= PrintableString
 
@@ -221,9 +221,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                  [Page 4]
+Vredendaal, et al.      Expires 22 September 2022               [Page 4]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
 2.  Overview of PQC algorithm and parameter OIDs
@@ -252,40 +252,40 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | kyber-512-r3                                                  |
    |---------+-----+-----------------------------------------------|
    |         |ASN.1| {..*.. pqc-kem-kyber kyber-512-r3 }           |
-   |         |dot. | 1.3.6.1.4.1.2.267.8.2.2                       |
+   |         |dot. |                                               |
    |---------+-----+-----------------------------------------------|
    | kyber-512-90s-r3                                              |
    |---------+-----+-----------------------------------------------|
    |         |ASN.1| {..*.. pqc-kem-kyber kyber-512-90s-r3}        |
-   |         |dot  | 1.3.6.1.4.1.2.267.10.2.2                      |
+   |         |dot  |                                               |
    |---------------+-----+-----------------------------------------|
    | kyber-768-r3                                                  |
    |---------+-----+-----------------------------------------------|
    |         |ASN.1| {..*.. pqc-kem-kyber kyber-768-r3 }           |
-   |         |dot  | 1.3.6.1.4.1.2.267.8.3.3                       |
+   |         |dot  |                                               |
    |---------------+-----+-----------------------------------------|
    | kyber-768-90s-r3                                              |
    |---------------+-----+-----------------------------------------|
    |         |ASN.1| {..*.. pqc-kem-kyber kyber-768-90s-r3 }       |
-   |         |dot  | 1.3.6.1.4.1.2.267.10.3.3                      |
+   |         |dot  |                                               |
    |---------+-----+-----------------------------------------------|
    | kyber-1024-r3                                                 |
    |---------+-----+-----------------------------------------------|
    |         |ASN.1| {..*.. pqc-kem-kyber kyber-1024-r3 }          |
-   |         |dot  | 1.3.6.1.4.1.2.267.8.4.4                       |
+   |         |dot  |                                               |
    |---------+-----+-----------------------------------------------|
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                  [Page 5]
+Vredendaal, et al.      Expires 22 September 2022               [Page 5]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
    | kyber-1024-90s-r3                                             |
    |---------+-----+-----------------------------------------------|
    |         |ASN.1| {..*.. pqc-kem-kyber kyber-1024-90s-r3}       |
-   |         |dot  | 1.3.6.1.4.1.2.267.10.4.4                      |
+   |         |dot  |                                               |
    |=========+=====+===============================================|
    | NTRU (PQC KEM)                                                |
    |=========+=====+===============================================|
@@ -321,7 +321,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | dilithium-4x4-r3                                              |
    |---------+-----+-----------------------------------------------|
    |         |ASN.1|{..*.. pqc-ds-dilithium dilithium-4x4-r3}      |
-   |         |dot  | 1.3.6.1.4.1.2.267.7.4.4                       |
+   |         |dot  |                                               |
    |---------------+-----+-----------------------------------------|
    | dilithium-4x4-aes-r3                                          |
    |---------+-----+-----------------------------------------------|
@@ -333,13 +333,13 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                  [Page 6]
+Vredendaal, et al.      Expires 22 September 2022               [Page 6]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
    |         |ASN.1| {..*.. pqc-ds-dilithium dilithium-6x5-r3}     |
-   |         | Dot | 1.3.6.1.4.1.2.267.7.6.5                       |
+   |         | Dot |                                               |
    |---------+-----+-----------------------------------------------|
    | dilithium-6x5-aes-r3                                          |
    |---------+-----+-----------------------------------------------|
@@ -349,7 +349,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | dilithium-8x7-r3                                              |
    |---------+-----+-----------------------------------------------|
    |         |ASN.1| {..*.. pqc-ds-dilithium dilithium-8x7-r3}     |
-   |         |Dot  | 1.3.6.1.4.1.2.267.7.8.7                       |
+   |         |Dot  |                                               |
    |---------+-----+-----------------------------------------------|
    | dilithium-8x7-aes-r3                                          |
    |---------+-----+-----------------------------------------------|
@@ -381,7 +381,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 2.1.  Key Formats
 
-   The Secret Key Format defined is from PKCS#8 [RFC5208] .  PKCS#8
+   The private key format defined is from PKCS#8 [RFC5208] .  PKCS#8
    PrivateKeyInfo is defined as:
 
 
@@ -389,9 +389,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                  [Page 7]
+Vredendaal, et al.      Expires 22 September 2022               [Page 7]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
    PrivateKeyInfo ::=  SEQUENCE {
@@ -409,12 +409,12 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    defined in the specific algorithm sections of this document.  For an
    overview see tables above and below.
 
-2.2.  Public Key Format based on [RFC5480]
+2.2.  Public Key Format based on [RFC5280]
 
-   RFC5480 subjectPublicKeyInfo is defined in as:
+   RFC5280 subjectPublicKeyInfo is defined in as:
 
 
-   subjectPublicKeyInfo := SEQUENCE {
+   SubjectPublicKeyInfo := SEQUENCE {
        algorithm          AlgorithmIdentifier  -- see chapter above
        subjectPublicKey   BIT STRING           -- see chapter below
    }
@@ -445,9 +445,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                  [Page 8]
+Vredendaal, et al.      Expires 22 September 2022               [Page 8]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
 3.  Classic McEliece
@@ -501,9 +501,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                  [Page 9]
+Vredendaal, et al.      Expires 22 September 2022               [Page 9]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
    |                         | f(z)=z^{13} + z^4 + z^3 + z + 1     |
@@ -557,9 +557,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                 [Page 10]
+Vredendaal, et al.      Expires 22 September 2022              [Page 10]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
    |                         | f(z)=z^{13} + z^4 + z^3 + z + 1     |
@@ -613,17 +613,21 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                 [Page 11]
+Vredendaal, et al.      Expires 22 September 2022              [Page 11]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
 3.2.  Key Details
 
-   Public key.  The public-key consists of * T: mt x k matrix Each row
-   of T is represented as a ceiling(k/8)-byte string, and the public key
-   is represented as the mt*ceiling(k/8)-byte concatenation of these
-   strings.  Secret key.  The secret key consists of five parameters:
+   Public key.  The public-key consists of
+
+   *  T: mt x k matrix
+
+   Each row of T is represented as a ceiling(k/8)-byte string, and the
+   public key is represented as the mt*ceiling(k/8)-byte concatenation
+   of these strings.  Private key.  The private key consists of five
+   parameters:
 
    *  delta: nonce
    *  C : column selections
@@ -631,7 +635,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    *  alpha: field orderings
    *  s : uniform random n-bit string
 
-   The size necessary to hold all secret key elements accounts to
+   The size necessary to hold all private key elements accounts to
    ceiling(l / 8) + [ceiling(nu / 8) | 8] + ceiling(m / 8) +
    ceiling((2*m - 1) * 2*m - 4) + ceiling(n / 8) bytes.  The resulting
    public key and private key sizes can be found in the table below.
@@ -639,7 +643,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
    |=====================+=================+================|
    | Parameter Set.      | Size of the     | Size of the    |
-   |                     | public key      | secret key     |
+   |                     | public key      | private key    |
    |                     | in bytes.       | in bytes       |
    |=====================+=================+================|
    | mceliece348864-r3   |       261120    |       6492     |
@@ -657,22 +661,22 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
                                   Figure 3
 
-3.3.  Secret Key Full Encoding
+3.3.  Private key Full Encoding
 
    Distributing a Classic McEliece private key with PKCS#8 involves
    including:
 
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 12]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
    *  mceliece{n}{t}[f]-r3 in the algorithm field of AlgorithmIdentifier
    *  McEliecePrivateKey in the privateKey field, which is an OCTET
       STRING.
-
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 12]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
 
    When a Classic McEliece public key is included in the distributed
    PrivateKeyInfo, the PublicKey field in McEliecePrivateKey is used
@@ -681,13 +685,13 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
    McEliecePrivateKey ::= SEQUENCE {
-       Version    INTEGER {v0(0)} -- version (round 3)
+       version    INTEGER {v0(0)} -- version (round 3)
        delta      OCTET STRING,   -- nonce
        C          OCTET STRING,   -- column selections
        g          OCTET STRING,   -- monic irreducible polynomial
        alpha      OCTET STRING,   -- field orderings
        s          OCTET STRING,   -- random n-bit string
-       PublicKey  [0] IMPLICIT McEliecePublicKey OPTIONAL
+       publicKey  [0] IMPLICIT McEliecePublicKey OPTIONAL
                                    -- see next section
    }
 
@@ -695,8 +699,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 3.4.  Public Key Full Encoding
 
 
-   Classic McEliece Public Key Format
-       McEliecePublicKey ::= SEQUENCE {
+   McEliecePublicKey ::= SEQUENCE {
        T       OCTET STRING    -- public key
    }
 
@@ -716,26 +719,29 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    strengths.
 
 
+
+
+
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 13]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
    |=========================+=====================================|
    | kyber-512-r3                                                  |
    |=========================+=====================================|
    | Parameter OID           | {..*.. kyber-512-90s-r3}            |
    |                         | 1.3.6.1.4.1.2.267.8.2.2             |
    | NIST Level Security     | Level 1                             |
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 13]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
-
    |-------------------------|-------------------------------------|
    | Parameters              | n= 256,                             |
    |                         | k=2                                 |
    |                         | q=3329                              |
-   |                         | nu_1=3                              |
-   |                         | nu_2=2                              |
+   |                         | eta_1=3                             |
+   |                         | eta_2=2                             |
    |                         | (d_u, d_v)=(10, 4)                  |
    |                         | delta=2^{-139}                      |
    |=========================+=====================================|
@@ -748,8 +754,8 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | Parameters              | n= 256,                             |
    |                         | k=2                                 |
    |                         | q=3329                              |
-   |                         | nu_1=3                              |
-   |                         | nu_2=2                              |
+   |                         | eta_1=3                             |
+   |                         | eta_2=2                             |
    |                         | (d_u, d_v)=(10, 4)                  |
    |                         | delta=2^{-139}                      |
    |=========================+=====================================|
@@ -762,8 +768,8 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | Parameters              | n= 256,                             |
    |                         | k=3                                 |
    |                         | q=3329                              |
-   |                         | nu_1=2                              |
-   |                         | nu_2=2                              |
+   |                         | eta_1=2                             |
+   |                         | eta_2=2                             |
    |                         | (d_u, d_v)=(10, 4)                  |
    |                         | delta=2^{-164}                      |
    |=========================+=====================================|
@@ -772,20 +778,20 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | Parameter OID           | {..*.. kyber-768-90s-r3}            |
    |                         | 1.3.6.1.4.1.2.267.10.3.3            |
    | NIST Level Security     | Level 5                             |
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 14]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
    |-------------------------|-------------------------------------|
    | Parameters              | n= 256,                             |
    |                         | k=3                                 |
    |                         | q=3329                              |
-   |                         | nu_1=2                              |
-   |                         | nu_2=2                              |
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 14]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
-
+   |                         | eta_1=2                             |
+   |                         | eta_2=2                             |
    |                         | (d_u, d_v)=(10, 4)                  |
    |                         | delta=2^{-164}                      |
    |=========================+=====================================|
@@ -798,8 +804,8 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | Parameters              | n= 256,                             |
    |                         | k=4                                 |
    |                         | q=3329                              |
-   |                         | nu_1=2                              |
-   |                         | nu_2=2                              |
+   |                         | eta_1=2                             |
+   |                         | eta_2=2                             |
    |                         | (d_u, d_v)=(11, 5)                  |
    |                         | delta=2^{-174}                      |
    |=========================+=====================================|
@@ -812,14 +818,29 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | Parameters              | n= 256,                             |
    |                         | k=4                                 |
    |                         | q=3329                              |
-   |                         | nu_1=2                              |
-   |                         | nu_2=2                              |
+   |                         | eta_1=2                             |
+   |                         | eta_2=2                             |
    |                         | (d_u, d_v)=(11, 5)                  |
    |                         | delta=2^{-174}                      |
    |=========================+=====================================|
 
 
                                   Figure 4
+
+
+
+
+
+
+
+
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 15]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
 
    The '90s' variants listed above differ in the symmetric primitives
    that are used internally.  By default, Kyber uses SHAKE-128 as XOF,
@@ -834,69 +855,73 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
    Public key.  The public-key consists of two parameters:
 
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 15]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
-
    *  t: encoded vector A*s+e, where A is a public matrix over a
       constant-sized polynomial ring, s and e are vectors over the same
       ring.
    *  rho: public seed (32 bytes)
 
    The size necessary to hold all public key elements is 12*k*n/8+32
-   bytes.  Secret key.  The secret key consists of 3 parameters:
+   bytes.  Private key.  The private key consists of 3 parameters:
 
-   *  s: encoded sample from a centered binomial distribution B_nu1
+   *  s: encoded sample from a centered binomial distribution B_{eta_1}
       (12*k*n/8 bytes)
-   *  z: a nonce (32 bytes)
    *  H(pk): hashed public key (32 bytes).  Kyber uses SHA3-256 as H by
       default.  The '90s' variants use SHA256 instead.
+   *  z: a nonce (32 bytes)
 
-   If the secret key is fully populated, it consists of 3 parameters.
-   The size necessary to hold all secret key elements accounts to
+   If the private key is fully populated, it consists of 3 parameters.
+   The size necessary to hold all private key elements accounts to
    12*k*n/8+64 bytes, not counting the optional public key.  The
    resulting public key and private key sizes are shown in the following
    table.
 
 
-   |==========================+=========+==========+=========|
-   | Algorithm OID            | Public  |   Secret |  Secret |
-   |                          | Key     |   Key    |  Key    |
-   |                          |         |          |(partial)|
-   |==========================+=========+==========+=========|
-   | kyber512-r3 /            |   800   |   832    |    32   |
-   | kyber512-90s-r3          |         |          |         |
-   |--------------------------|---------|----------|---------|
-   | kyber768-r3 /            |  1184   |   1216   |    32   |
-   | kyber768-90s-r3          |         |          |         |
-   |--------------------------|--------------------|---------|
-   | kyber1024-r3 /           |  1568   |   1600   |    32   |
-   | kyber1024-90s-r3         |         |          |         |
-   |==========================+=========+==========+=========|
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 16]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
+   |==========================+=========+==========+===========|
+   | Algorithm OID            | Public  |   Private |  Private |
+   |                          | Key     |   Key    |  Key      |
+   |                          |         |          |(partial)  |
+   |==========================+=========+==========+===========|
+   | kyber512-r3 /            |   800   |   832    |    32     |
+   | kyber512-90s-r3          |         |          |           |
+   |--------------------------|---------|----------|-----------|
+   | kyber768-r3 /            |  1184   |   1216   |    32     |
+   | kyber768-90s-r3          |         |          |           |
+   |--------------------------|--------------------|-----------|
+   | kyber1024-r3 /           |  1568   |   1600   |    32     |
+   | kyber1024-90s-r3         |         |          |           |
+   |==========================+=========+==========+===========|
 
 
                                   Figure 5
 
-4.3.  Secret Key Full Encoding
+4.3.  Private key Full Encoding
 
    Distributing a Kyber private key with PKCS#8 requires:
 
    *  kyber-(n*k)-r3 in the algorithm field of AlgorithmIdentifier
    *  KyberPrivateKey in the privateKey field, which is an OCTET STRING.
-
-
-
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 16]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
 
    When a Kyber public key is included in the distributed
    PrivateKeyInfo, the PublicKey field in KyberPrivateKey is used (see
@@ -905,16 +930,31 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
    KyberPrivateKey ::= SEQUENCE {
-       Version     INTEGER {v0(0)}   -- version (round 3)
-       nonce       OCTET STRING,     -- z
+       version     INTEGER {v0(0)}   -- version (round 3)
        s           OCTET STRING,     -- sample s
-       PublicKey   [0] IMPLICIT KyberPublicKey OPTIONAL,
+       publicKey   [0] IMPLICIT KyberPublicKey OPTIONAL,
                                      -- see next section
        hpk         OCTET STRING      -- H(pk)
+       nonce       OCTET STRING,     -- z
    }
 
 
-4.4.  Secret Key Partial Encoding
+
+
+
+
+
+
+
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 17]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
+4.4.  Private key Partial Encoding
 
    The partially populated parameter set uses of the fact that some
    parameters can be regenerated.  In this case, only the initial seed
@@ -931,11 +971,11 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
    KyberPrivateKey ::= SEQUENCE {
        version     INTEGER {v0(0)}   -- version (round 3)
-       nonce       OCTET STRING,     -- d
        s           OCTET STRING,     -- EMPTY
-       PublicKey   [0] IMPLICIT KyberPublicKey OPTIONAL,
+       publicKey   [0] IMPLICIT KyberPublicKey OPTIONAL,
                                      -- see next section
        hpk         OCTET STRING      -- EMPTY
+       nonce       OCTET STRING,     -- d
    }
 
 
@@ -945,13 +985,6 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    the inverse of Decode_12 as defined in Algorithm 3 of the Kyber round
    3 specification.  The size of t is 12*k*n/8 bytes.  The seed 'rho' is
    a 32 byte OCTET STRING.
-
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 17]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
    KyberPublicKey ::= SEQUENCE {
@@ -968,6 +1001,15 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    Submission: https://csrc.nist.gov/CSRC/media/Projects/post-quantum-
    cryptography/documents/round-3/submissions/NTRU-Round3.zip
 
+
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 18]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
 5.1.  Algorithm Parameter Identifiers
 
    Below are the NTRU parameter sets.  Note that the definition of
@@ -983,10 +1025,10 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | NIST Level Security     | Level 1                             |
    |-------------------------|-------------------------------------|
    | Parameters              | Dimension/Degree n= 509             |
-   |                         | Polynomial  Phin= (xn - 1)/(x-1     |
+   |                         | Polynomial  Phin=(x^n - 1)/(x-1)    |
    |                         | Polynomial  Phi1=(x-1)              |
    |                         | Modulus p=3                         |
-   |                         | Modulus q= 2048                     |
+   |                         | Modulus q=2048                      |
    |=========================+=====================================|
    | ntruhps2048677-r3                                             |
    |=========================+=====================================|
@@ -994,28 +1036,20 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    |                         | <.  >                               |
    | NIST Level Security     | Level 3 (1) see spec.               |
    |-------------------------|-------------------------------------|
-   | Parameters              | Dimension/Degree n= 677             |
-   |                         | Polynomial  Phin= (xn - 1)/(x-1)    |
+   | Parameters              | Dimension/Degree n=677              |
+   |                         | Polynomial  Phin=(x^n - 1)/(x-1)    |
    |                         | Polynomial  Phi1=(x-1)              |
    |                         | Modulus p=3                         |
-   |                         | Modulus q= 2048                     |
+   |                         | Modulus q=2048                      |
    |=========================+=====================================|
    | ntruhps4096821-r3                                             |
    |=========================+=====================================|
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 18]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
-
    | Parameter OID           | {..*.. ntruhps4096821-r3}           |
    |                         | <.>                                 |
    | NIST Level Security     | Level 3 (1) see spec.               |
    |-------------------------|-------------------------------------|
    | Parameters              | Dimension/Degree n= 821             |
-   |                         | Polynomial  Phin= (xn - 1)/(x-1)    |
+   |                         | Polynomial  Phin=(x^n - 1)/(x-1)    |
    |                         | Polynomial  Phi1=(x-1)              |
    |                         | Modulus p=3                         |
    |                         | Modulus q= 4096                     |
@@ -1024,13 +1058,21 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    |=========================+=====================================|
    | Parameter OID           | {..*.. ntruhrss701-r3}              |
    |                         | <.>                                 |
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 19]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
    | NIST Level Security     | Level 5 (3)  see spec.              |
    |-------------------------|-------------------------------------|
    | Parameters              | Dimension/Degree n= 701             |
-   |                         | Polynomial  Phin= (xn - 1)/(x-1)    |
+   |                         | Polynomial  Phin= (x^n - 1)/(x-1)   |
    |                         | Polynomial  Phi1=(x-1)              |
    |                         | Modulus p=3                         |
-   |                         | Modulus q= 8192                     |
+   |                         | Modulus q=8192                      |
    |=========================+=====================================|
 
 
@@ -1043,47 +1085,45 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
    Public key.  The public-key consists of a single parameter :
 
-   *  a polynomial h that satisfies h?f=3?g in the ring Rq=Z[x]/(q,
-      Phi1?Phin).
+   *  a polynomial h that satisfies h*f=3*g in the ring Rq=Z[x]/(q,
+      Phi_1*Phi_n).
 
    This means there are n - 1 coefficients of size at most q in the
    public key, and the size necessary to store the polynomial is
-   therefore is ceiling((n - 1)?log2(q)/8) bytes.  The resulting sizes
-   for the parameter sets can be found in the Table below.  Secret key.
-   The secret key consists of 4 parameters:
+   therefore is ceiling((n - 1)*log2(q)/8) bytes.  The resulting sizes
+   for the parameter sets can be found in the Table below.  Private key.
+   The private key consists of 4 parameters:
 
    *  a polynomial f that is a ternary (coefficients fi are in {-1, 0,
       1}) polynomial of degree n - 2, with the additional property that
-      &#8721;_(i=0)^(n-3) f_i?? f?_(i+1)&#8805;0,
-   *  a polynomial fp that satisfies f?fp=1 in the ring Rq=Z[x]/(3,
-      Phin),
-
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 19]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
-
-   *  a polynomial hq that satisfies h?hq=1 in the ring Rq=Z[x]/(q,
-      Phin), and
+      &#8721;_(i=0)^{n-3} f_i*f_{i+1}&#8805;0,
+   *  a polynomial f_p that satisfies f*f_p=1 in the ring Rq=Z[x]/(3,
+      Phi_n),
+   *  a polynomial h_q that satisfies h*h_q=1 in the ring Rq=Z[x]/(q,
+      Phi_n), and
    *  a seed=fg_bits || prf_key=f_bits || g_bits || prf_key containing
       the randomness for the key sampling and the implicit rejection
       mechanism.  Optionally implementers may expand this from a 32-byte
       seed.
 
    This means there are 2 polynomials, f and fp, having n - 1
-   coefficients with absolute value at most 1 in the secret key.  For
+   coefficients with absolute value at most 1 in the private key.  For
    these polynomials, the packing algorithm in Section 1.8.7 of the
    Specification allows to pack 5 coefficients in a byte, so the storage
    requirement to store each is ceiling((n - 1)/5) bytes.  Additionally
-   hq is part of the secret key, which requires the same storage size as
-   that of the public key h, i.e. ceiling((n - 1)?log2(q)/8) bytes.  For
-   the seed bytes, the specification recommends:
+   hq is part of the private key, which requires the same storage size
+   as that of the public key h, i.e. ceiling((n - 1)*log2(q)/8) bytes.
+   For the seed bytes, the specification recommends:
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 20]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
 
    *  >f_bits having n - 1 bytes,
-   *  >g_bits having n - 1 bytes for ntruhrss701, ceiling(30/8?(n-1))
+   *  >g_bits having n - 1 bytes for ntruhrss701, ceiling(30/8*(n-1))
       bytes for the other parameter sets,
    *  prf_key having 32 bytes.
 
@@ -1093,33 +1133,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    must be replaced by key_seed_bits=sample_key_bits+prf_key_bits.  The
    impact of these options are indicated as 32-byte seed/expanded seed
    in the Table below.  Parameter Set Size of the public key in bytes
-   Size of the secret key in bytes
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 20]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
+   Size of the private key in bytes
 
 
    |=====================+==============================|
@@ -1127,37 +1141,44 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    |---------------------|------------------------------|
    | Public Key (Bytes)  | 699                          |
    | seed/expanded seed  | 935 / 3348                   |
-   | f,fp,hq,seed        | 102,102,699,32/2445          |
+   | f,f_p,h_q,seed      | 102,102,699,32/2445          |
    |=====================+==============================|
    | ntruhps2048677-r3                                  |
    |---------------------|------------------------------|
    | Public Key (Bytes)  | 699                          |
    | seed/expanded seed  | 935 / 3348                   |
-   | f,fp,hq,seed        | 102,102,699,32/2445          |
+   | f,f_p,h_q,seed      | 102,102,699,32/2445          |
    |=====================+==============================|
    | ntruhps2048677-r3                                  |
    |---------------------|------------------------------|
-   | Public Key (Bytes)  |    930                          |
+   | Public Key (Bytes)  |    930                       |
    | seed/expanded seed  | 1234 / 4445                  |
-   | (f,fp,hq,seed)      | 136,136,930,32/3243          |
+   | (f,f_p,h_q,seed)    | 136,136,930,32/3243          |
    |=====================+==============================|
    | ntruhps4096821-r3                                  |
    |---------------------|------------------------------|
    | Public Key (Bytes)  | 1230                         |
    | seed/expanded seed  | 1590 / 5485                  |
-   | (f,fp,hq,seed)      | 164,164,1230,32/3927         |
+   | (f,f_p,h_q,seed)    | 164,164,1230,32/3927         |
    |=====================+==============================|
    | ntruhrss701-r3                                     |
    |---------------------|------------------------------|
    | Public Key (Bytes)  | 1138                         |
    | seed/expanded seed  | 1450 / 2850                  |
-   | (f,fp,hq,seed)      | 140,140,1138,32/1432         |
+   | (f,f_p,h_q,seed)    | 140,140,1138,32/1432         |
    |=====================+==============================|
 
 
                                   Figure 7
 
-5.3.  Secret Key Full Encoding
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 21]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
+5.3.  Private key Full Encoding
 
    An NTRU private key encoded according with PKCS#8 MUST include the
    following two fields:
@@ -1166,24 +1187,12 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
       AlgorithmIdentifier
    *  NTRUPrivateKey in the privateKey field, which is an OCTET STRING.
 
-
-
-
-
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 21]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
-
    When a NTRU public key is included in the distributed PrivateKeyInfo,
    the PublicKey field in NTRUPrivateKey is used (see description of
-   NTRUPublicKey below).  An NTRU secret key contains f, fp and hq, as
-   well as a seed.  The octet string format indicates the length of the
-   string to follow, and indicates whether the seed or expanded seed is
-   used.
+   NTRUPublicKey below).  An NTRU private key contains f, f_p and h_q,
+   as well as a seed.  The octet string format indicates the length of
+   the string to follow, and indicates whether the seed or expanded seed
+   is used.
 
 
    NTRUPrivateKey ::= SEQUENCE {
@@ -1192,15 +1201,15 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
        fp         OCTET STRING,      -- short integer polynomial gp
        hq         OCTET STRING,      -- mod q integer polynomial hq
        seed       OCTET STRING,      -- fg_bits/prf_bits (or their seed)
-       PublicKey [0] IMPLICIT NTRUPublicKey OPTIONAL -- see next section
+       publicKey [0] IMPLICIT NTRUPublicKey OPTIONAL -- see next section
    }
 
 
 5.4.  Public Key Full Encoding
 
    From the NTRU specification, the public key contains h.  Each
-   coefficient of h is encoded as an ? bit sequence, where ?=ceiling((n
-   - 1)?log2(q)).  Coefficients are then concatenated (two's complement,
+   coefficient of h is encoded as an l bit sequence, where l=ceiling((n
+   - 1)*log2(q)).  Coefficients are then concatenated (two's complement,
    big endian convention).  The final bit string is zero padded to fit
    into a byte sequence.  NTRUPublicKey := SEQUENCE { h OCTET STRING --
    integer polynomial h }
@@ -1214,24 +1223,20 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    post-quantum-cryptography/documents/round-3/submissions/SABER-
    Round3.zip
 
+
+
+
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 22]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
 6.1.  Algorithm Parameter Identifiers
 
    Saber has three parameter sets shown in the table below
-
-
-
-
-
-
-
-
-
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 22]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
    |=========================+=====================================|
@@ -1242,7 +1247,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | NIST Level Security     | Level 1                             |
    |-------------------------|-------------------------------------|
    | Parameters              | Degree n= 256                       |
-   |                         | rank of the module ?= 2             |
+   |                         | rank of the module l=2              |
    |                         | binomial distribution with u=10     |
    |                         | Modulus q=2^{13} and p=2^{10}       |
    |=========================+=====================================|
@@ -1253,7 +1258,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | NIST Level Security     | Level 3                             |
    |-------------------------|-------------------------------------|
    | Parameters              | Degree n= 256                       |
-   |                         | rank of the module ?= 3             |
+   |                         | rank of the module l=3              |
    |                         | binomial distribution with u=8      |
    |                         | Modulus q=2^{13} and p=2^{10}       |
    |=========================+=====================================|
@@ -1264,7 +1269,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | NIST Level Security     | Level 5                             |
    |-------------------------|-------------------------------------|
    | Parameters              | Degree n= 256                       |
-   |                         | rank of the module ?= 4             |
+   |                         | rank of the module l=4              |
    |                         | binomial distribution with u=6      |
    |                         | Modulus q=2^{13} and p=2^{10}       |
    |=========================+=====================================|
@@ -1272,7 +1277,18 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
                                   Figure 8
 
-   The rank of the module is denoted ? and differs per parameter set.
+   The rank of the module is denoted l and differs per parameter set.
+
+
+
+
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 23]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
 
 6.2.  Key Details
 
@@ -1282,44 +1298,36 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    *  polynomials of degree 256 with 10-bit integer coefficients denoted
       by vector b.
 
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 23]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
-
    This means the size of the public key can be stored using
-   ?*256*10+256 bits.  The size of the public key as used in the three
+   l*256*10+256 bits.  The size of the public key as used in the three
    parameter sets can be found in the Table below.
 
-   Secret key.  The secret key s consists of three parameters:
+   Private key.  The private key s consists of three parameters:
 
    *  a 256-bit uniform random value z
-   *  ? polynomials of degree 256 with 13-bit integer coefficients
+   *  l polynomials of degree 256 with 13-bit integer coefficients
       denoted by s
    *  H(pk): hashed public key (32 bytes)
 
-   This means the secret key can be stored using 512+?*256*13 bits.  The
-   size of the secret key as used in the three parameter sets can be
-   found in the Table below.
+   This means the private key can be stored using 512+l*256*13 bits.
+   The size of the private key as used in the three parameter sets can
+   be found in the Table below.
 
 
-   |==========================+=========+==========|
-   | Algorithm                | Public  |   Secret |
-   |                          | Key     |   Key    |
-   |                          | Length  |   Length |
-   |==========================+=========+==========+
-   | LightSaber-r3            |    672  |    896   |
-   | Saber-r3                 |    992  |   1312   |
-   | FireSaber-r3             |   1312  |   1728   |
-   |==========================+=========+==========|
+   |==========================+=========+===========|
+   | Algorithm                | Public  |   Private |
+   |                          | Key     |   Key     |
+   |                          | Length  |   Length  |
+   |==========================+=========+===========+
+   | LightSaber-r3            |    672  |    896    |
+   | Saber-r3                 |    992  |   1312    |
+   | FireSaber-r3             |   1312  |   1728    |
+   |==========================+=========+===========|
 
 
                                   Figure 9
 
-6.3.  Secret Key Full Encoding
+6.3.  Private key Full Encoding
 
    A SABER private key encoded according with PKCS#8 MUST include the
    following two fields:
@@ -1328,29 +1336,26 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
       FireSaber-r3} in the algorithm field of AlgorithmIdentifier
    *  SABERPrivateKey in the privateKey field, which is an OCTET STRING.
 
+
+
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 24]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
    When a SABER public key is included in the distributed
    PrivateKeyInfo, the PublicKey field in SABERPrivateKey is used (see
    the description below).
-
-
-
-
-
-
-
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 24]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
    SABERPrivateKey ::= SEQUENCE {
        version     INTEGER  {v0(0)}    -- version (round 3)
        z           OCTET STRING,       -- 32-byte random value z
        s           OCTET STRING,       -- short integer polynomial s
-       PublicKey   [0] IMPLICIT SABERPublicKey OPTIONAL,
+       publicKey   [0] IMPLICIT SABERPublicKey OPTIONAL,
                                        -- see next section
        hpk         OCTET STRING        -- H(pk)
    }
@@ -1388,24 +1393,24 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    |                         | 1.3.6.1.4.1.2.267.7.4.4             |
    | NIST Level Security     | Level 2                             |
    |-------------------------|-------------------------------------|
-   | Parameters              | Polynomial Ring Zq[x]/( x^n +1)     |
-   |                         | Dimension/Degree n= 256             |
+   | Parameters              | Polynomial Ring Zq[x]/( x^n+1 )     |
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 25]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
+   |                         | Dimension/Degree n=256              |
    |                         | Modulus q=8380417                   |
    |                         | Dropped bits from t: d=13           |
    |                         | # of +-1's in c: tau=39             |
    |                         | challenge entropy=192               |
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 25]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
-
    |                         | gamma coefficient range: gamma1=2^17|
    |                         | low-order rounding range: gamma2=(q-|
    |                         | 1)/88                               |
-   |                         | Secret Key Range (nu)=2             |
+   |                         | Private key Range eta=2             |
    |                         | Dimensions of A: (k,l)=(4,4)        |
    |                         | Max # of 1's in the hint h: w=80    |
    |                         | Repetitions=4.25                    |
@@ -1417,7 +1422,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | NIST Level Security     | Level 2                             |
    |-------------------------|-------------------------------------|
    | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
-   |                         | Dimension/Degree n= 256             |
+   |                         | Dimension/Degree n=256              |
    |                         | Modulus q=8380417                   |
    |                         | Dropped bits from t: d=13           |
    |                         | # of +-1's in c: tau=39             |
@@ -1425,7 +1430,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    |                         | y coefficient range: gamma1=2^17    |
    |                         | low-order rounding range:gamma2=(q- |
    |                         | -1)/88                              |
-   |                         | Secret Key Range (nu)=2             |
+   |                         | Private key Range eta=2             |
    |                         | Dimensions of A: (k,l)=(4,4)        |
    |                         | Max # of 1's in the hint h: w=80    |
    |                         | Repetitions=4.25                    |
@@ -1437,35 +1442,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | NIST Level Security     | Level 3                             |
    |-------------------------|-------------------------------------|
    | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
-   |                         | Dimension/Degree n= 256             |
-   |                         | Modulus q=8380417                   |
-   |                         | Dropped bits from t: d=13           |
-   |                         | # of +-1's in c: ?=49               |
-   |                         | challenge entropy=225               |
-   |                         | y coefficient range: gamma1=2^19    |
-   |                         | low-order rounding range:gamma2=(q- |
-   |                         | -1)/32                              |
-   |                         | Secret Key Range (nu)=4             |
-   |                         | Dimensions of A: (k,l)=(6,5)        |
-   |                         | Max # of 1's in the hint h: w=55    |
-   |                         | Repetitions=5.1                     |
-   |=========================+=====================================|
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 26]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
-
-   | dilithium-6x5-aes-r3                                          |
-   |=========================+=====================================|
-   | Parameter OID           | {..*.. dilithium-6x5-aes-r3}        |
-   |                         | <.>                                 |
-   | NIST Level Security     | Level 3                             |
-   |-------------------------|-------------------------------------|
-   | Parameters              | Polynomial Ring Zq[x]/( x^n +1 )    |
-   |                         | Dimension/Degree n= 256             |
+   |                         | Dimension/Degree n=256              |
    |                         | Modulus q=8380417                   |
    |                         | Dropped bits from t: d=13           |
    |                         | # of +-1's in c: tau=49             |
@@ -1473,7 +1450,35 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    |                         | y coefficient range: gamma1=2^19    |
    |                         | low-order rounding range:gamma2=(q- |
    |                         | -1)/32                              |
-   |                         | Secret Key Range (nu)=4             |
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 26]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
+   |                         | Private key Range eta=4             |
+   |                         | Dimensions of A: (k,l)=(6,5)        |
+   |                         | Max # of 1's in the hint h: w=55    |
+   |                         | Repetitions=5.1                     |
+   |=========================+=====================================|
+   | dilithium-6x5-aes-r3                                          |
+   |=========================+=====================================|
+   | Parameter OID           | {..*.. dilithium-6x5-aes-r3}        |
+   |                         | <.>                                 |
+   | NIST Level Security     | Level 3                             |
+   |-------------------------|-------------------------------------|
+   | Parameters              | Polynomial Ring Zq[x]/( x^n +1 )    |
+   |                         | Dimension/Degree n=256              |
+   |                         | Modulus q=8380417                   |
+   |                         | Dropped bits from t: d=13           |
+   |                         | # of +-1's in c: tau=49             |
+   |                         | challenge entropy=225               |
+   |                         | y coefficient range: gamma1=2^19    |
+   |                         | low-order rounding range:gamma2=(q- |
+   |                         | -1)/32                              |
+   |                         | Private key Range eta=4             |
    |                         | Dimensions of A: (k,l)=(6,5)        |
    |                         | Max # of 1's in the hint h: w=55    |
    |                         | Repetitions=5.1                     |
@@ -1485,35 +1490,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | NIST Level Security     | Level 5                             |
    |-------------------------|-------------------------------------|
    | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
-   |                         | Dimension/Degree n= 256             |
-   |                         | Modulus q=8380417                   |
-   |                         | Dropped bits from t: d=13           |
-   |                         | # of +-1's in c: tau=60             |
-   |                         | challenge entropy=257               |
-   |                         | y coefficient range: ?1=2^19        |
-   |                         | low-order rounding range:gamma2=(q- |
-   |                         | -1)/32                              |
-   |                         | Secret Key Range (nu)=2             |
-   |                         | Dimensions of A: (k,l)=(8,7)        |
-   |                         | Max # of 1's in the hint h: w=75    |
-   |                         | Repetitions=3.85                    |
-   |=========================+=====================================|
-   | dilithium-8x7-aes-r3                                          |
-   |=========================+=====================================|
-   | Parameter OID           | {..*.. dilithium-8x7-aes-r3}        |
-   |                         | <.>                                 |
-   | NIST Level Security     | Level 5                             |
-   |-------------------------|-------------------------------------|
-   | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
-   |                         | Dimension/Degree n= 256             |
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 27]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
-
+   |                         | Dimension/Degree n=256              |
    |                         | Modulus q=8380417                   |
    |                         | Dropped bits from t: d=13           |
    |                         | # of +-1's in c: tau=60             |
@@ -1521,7 +1498,35 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    |                         | y coefficient range: gamma1=2^19    |
    |                         | low-order rounding range:gamma2=(q- |
    |                         | -1)/32                              |
-   |                         | Secret Key Range (nu)=2             |
+   |                         | Private key Range eta=2             |
+   |                         | Dimensions of A: (k,l)=(8,7)        |
+   |                         | Max # of 1's in the hint h: w=75    |
+   |                         | Repetitions=3.85                    |
+   |=========================+=====================================|
+   | dilithium-8x7-aes-r3                                          |
+   |=========================+=====================================|
+   | Parameter OID           | {..*.. dilithium-8x7-aes-r3}        |
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 27]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
+   |                         | <.>                                 |
+   | NIST Level Security     | Level 5                             |
+   |-------------------------|-------------------------------------|
+   | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
+   |                         | Dimension/Degree n=256              |
+   |                         | Modulus q=8380417                   |
+   |                         | Dropped bits from t: d=13           |
+   |                         | # of +-1's in c: tau=60             |
+   |                         | challenge entropy=257               |
+   |                         | y coefficient range: gamma1=2^19    |
+   |                         | low-order rounding range:gamma2=(q- |
+   |                         | -1)/32                              |
+   |                         | Private key Range eta=2             |
    |                         | Dimensions of A: (k,l)=(8,7)        |
    |                         | Max # of 1's in the hint h: w=75    |
    |                         | Repetitions=3.85                    |
@@ -1546,7 +1551,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    The size necessary to hold all public key elements accounts to
    32+320*k bytes.
 
-   Secret key.  The secret key consists of 6 parameters:
+   Private key.  The private key consists of 6 parameters:
 
    *  rho: nonce
    *  K: a key/seed/D
@@ -1555,38 +1560,39 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    *  s2: vector (K)
    *  t0: k polynomials
 
-   If the secret key is fully populated, it consists of 6 parameters.
-   The size necessary to hold all secret key elements accounts to
-   32+32+32+32*[(k+l)*ceiling(log(2*nu+1))+13*k] bytes.  The resulting
+
+
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 28]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
+   If the private key is fully populated, it consists of 6 parameters.
+   The size necessary to hold all private key elements accounts to
+   32+32+32+32*[(k+l)*ceiling(log(2*eta+1))+13*k] bytes.  The resulting
    public key and private key sizes can be found in the table below.
 
 
-
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 28]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
-
-   |=========================+========+========+=========+=========|
-   | Algorithm               | Public | Secret | Partial | Partial |
-   |                         | Key    | Key SK | SK (V1) | SK (V2) |
-   |                         | Length | Length | Length  | Length  |
-   |=========================+========+========+=========+=========+
-   | dilithium-4x4-r3        | 1312   | 2528   |   64    |    32   |
-   | dilithium-4x4-aes-r3    | 1312   | 2528   |   64    |    32   |
-   | dilithium-6x5-r3        | 1952   | 4000   |   64    |    32   |
-   | dilithium-6x5-aes-r3    | 1952   | 4000   |   64    |    32   |
-   | dilithium-8x7-r3        | 2596   | 4864   |   64    |    32   |
-   | dilithium-8x7-aes-r3    | 2592   | 4864   |   64    |    32   |
-   |=========================+========+========+=========+=========|
+   |=========================+========+=========+=========+=========|
+   | Algorithm               | Public | Private | Partial | Partial |
+   |                         | Key    | Key SK  | SK (V1) | SK (V2) |
+   |                         | Length | Length  | Length  | Length  |
+   |=========================+========+=========+=========+=========+
+   | dilithium-4x4-r3        | 1312   | 2528    |   64    |    32   |
+   | dilithium-4x4-aes-r3    | 1312   | 2528    |   64    |    32   |
+   | dilithium-6x5-r3        | 1952   | 4000    |   64    |    32   |
+   | dilithium-6x5-aes-r3    | 1952   | 4000    |   64    |    32   |
+   | dilithium-8x7-r3        | 2592   | 4864    |   64    |    32   |
+   | dilithium-8x7-aes-r3    | 2592   | 4864    |   64    |    32   |
+   |=========================+========+=========+=========+=========|
 
 
                                  Figure 11
 
-7.3.  Secret Key Full Encoding
+7.3.  Private key Full Encoding
 
    A Dilithium private key encoded according with PKCS#8 MUST include
    the following two fields:
@@ -1601,6 +1607,25 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    ASN.1 Encoding for a Dilithium private key for fully populated:
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 29]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
+
+
    DilithiumPrivateKey ::= SEQUENCE {
        version     INTEGER {v0(0)}     -- version (round 3)
        nonce       BIT STRING,         -- rho
@@ -1609,24 +1634,12 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
        s1          BIT STRING,         -- vector(L)
        s2          BIT STRING,         -- vector(K)
        t0          BIT STRING,
-       PublicKey  [0] IMPLICIT DilithiumPublicKey OPTIONAL
+       publicKey  [0] IMPLICIT DilithiumPublicKey OPTIONAL
                                        -- see next section
    }
 
 
-
-
-
-
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 29]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
-
-
-7.4.  Secret Key Partial Encoding Option 1
+7.4.  Private key Partial Encoding Option 1
 
    In option 1 of Dilithium partial encoding the rho (nonce) and the
    seed (key) are used to regenerate the full key.  Note: There are a
@@ -1648,16 +1661,25 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
        s1          BIT STRING,         -- EMPTY
        s2          BIT STRING,         -- EMPTY
        t0          BIT STRING,         -- EMPTY
-       PublicKey   [0] IMPLICIT DilithiumPublicKey OPTIONAL
+       publicKey   [0] IMPLICIT DilithiumPublicKey OPTIONAL
                                        -- see next section
    }
 
 
-7.5.  Secret Key Partial Encoding Option 2
+7.5.  Private key Partial Encoding Option 2
 
    In option 2 of Dilithium partial encoding only zeta (nonce) is used
    to regenerate the full key.  The ASN.1 encoding for this is defined
    as follows:
+
+
+
+
+
+
+Vredendaal, et al.      Expires 22 September 2022              [Page 30]
+
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
    DilithiumPrivateKey ::= SEQUENCE {
@@ -1668,18 +1690,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
        s1          BIT STRING,         -- EMPTY
        s2          BIT STRING,         -- EMPTY
        t0          BIT STRING,         -- EMPTY
-       PublicKey   [0] IMPLICIT DilithiumPublicKey OPTIONAL
+       publicKey   [0] IMPLICIT DilithiumPublicKey OPTIONAL
                                       -- see next section
    }
-
-
-
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 30]
-
-Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 7.6.  Public Key Full Encoding
@@ -1720,22 +1733,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vredendaal, et al.         Expires 13 May 2022                 [Page 31]
+Vredendaal, et al.      Expires 22 September 2022              [Page 31]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
    |=========================+=====================================|
@@ -1746,13 +1746,13 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | NIST Level Security     | Level 1                             |
    |-------------------------|-------------------------------------|
    | Parameters              | Dimension/Degree n = 512            |
-   |                         | Polynomial Phi = 1+X{n}             |
+   |                         | Polynomial Phi = 1+x^n              |
    |                         | Modulus q = 12289                   |
    |                         | Max. signature square norm          |
-   |                         | floor (beta2) = 34034726            |
+   |                         | floor (beta^2) = 34034726           |
    |                         | Standard deviation = 165.736617183  |
-   |                         | sigmamax = 1.8205                   |
-   |                         | sigmamin = 1.27783369               |
+   |                         | sigma_{max} = 1.8205                |
+   |                         | sigma_{min} = 1.27783369            |
    |=========================+=====================================|
    | falcon1024-r3                                                 |
    |=========================+=====================================|
@@ -1761,13 +1761,13 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    | NIST Level Security     | Level 5                             |
    |-------------------------|-------------------------------------|
    | Parameters              | Dimension/Degree n = 1024           |
-   |                         | Polynomial Phi = 1+X{n}             |
+   |                         | Polynomial Phi = 1+x^n              |
    |                         | Modulus q = 12289                   |
    |                         | Max. signature square norm          |
-   |                         | floor (beta2) = 34034726            |
+   |                         | floor (beta^2) = 34034726           |
    |                         | Standard deviation = 168.388571447  |
-   |                         | sigmamax = 1.8205                   |
-   |                         | sigmamin = 1.298280334              |
+   |                         | sigma_{max} = 1.8205                |
+   |                         | sigma_{min} = 1.298280334           |
    |=========================+=====================================|
 
 
@@ -1775,7 +1775,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 8.2.  Key Details
 
-   The FALCON secret key contains the key components f, g and F.  Each
+   The FALCON private key contains the key components f, g and F.  Each
    coefficient of f and g is encoded over a fixed number of bits, which
    depends on the degree of f and g: 6 bits each for degree 512
    (parameter name = falcon512-r3) and 5 bits each for degree 1024
@@ -1783,35 +1783,35 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    regardless of its degree.  Each coefficient uses signed encoding,
    with two's complement for negative values.  Moreover, the minimal
    value is forbidden, e.g. when using degree 512, the valid range for a
-   coefficient of f or g is ?31 to +31; ?32 is not allowed.
+   coefficient of f or g is -31 to +31; -32 is not allowed.
 
 
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                 [Page 32]
+Vredendaal, et al.      Expires 22 September 2022              [Page 32]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
-   |==========================+=========+==========|
-   | Algorithm OID            | Params  |   Secret |
-   |                          |         |   Key    |
-   |                          |         |   Length |
-   |==========================+=========+==========+
-   | falcon512-r3             | f=384   | 1280     |
-   |                          | g=384   |          |
-   |                          | F=512   |          |
-   |--------------------------+---------+----------|
-   | falcon1024-r3            | f=640   | 2304     |
-   |                          | g=640   |          |
-   |                          | F=1024  |          |
-   |==========================+=========+==========+
+   |==========================+=========+===========|
+   | Algorithm OID            | Params  |   Private |
+   |                          |         |   Key     |
+   |                          |         |   Length  |
+   |==========================+=========+===========+
+   | falcon512-r3             | f=384   | 1280      |
+   |                          | g=384   |           |
+   |                          | F=512   |           |
+   |--------------------------+---------+-----------|
+   | falcon1024-r3            | f=640   | 2304      |
+   |                          | g=640   |           |
+   |                          | F=1024  |           |
+   |==========================+=========+===========+
 
 
                                  Figure 13
 
-8.3.  Secret Key Full Encoding
+8.3.  Private key Full Encoding
 
    Encoding a FALCON private key with PKCS#8 must include the following
    two fields:
@@ -1830,8 +1830,8 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
        version     INTEGER {v2(1)}    -- syntax version 2 (round 3)
        f           OCTET STRING,      -- short integer polynomial f
        g           OCTET STRING,      -- short integer polynomial g
-       F           OCTET STRING,      -- short integer polynomial F
-       PublicKey   [0] IMPLICIT FALCONPublicKey  OPTIONAL
+       f           OCTET STRING,      -- short integer polynomial F
+       publicKey   [0] IMPLICIT FALCONPublicKey  OPTIONAL
                                       -- see next section
    }
 
@@ -1845,9 +1845,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                 [Page 33]
+Vredendaal, et al.      Expires 22 September 2022              [Page 33]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
 8.4.  Public Key Full Encoding
@@ -1901,9 +1901,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                 [Page 34]
+Vredendaal, et al.      Expires 22 September 2022              [Page 34]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
    |=========================+=====================================|
@@ -1957,9 +1957,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                 [Page 35]
+Vredendaal, et al.      Expires 22 September 2022              [Page 35]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
 9.2.  Key Details
@@ -1976,8 +1976,8 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
    specification), this can be reduced to m*n*(n+1)/2 elements of F.
    The size necessary to hold all public key elements accounts to
    m*n*(n+1)/16*f bytes, where f=4 for rainbowI and 8 for rainbowIII and
-   rainbowV.  For all parameter sets ell is 16 bytes.  Secret key.  The
-   secret key consists of 4 parameters:
+   rainbowV.  For all parameter sets ell is 16 bytes.  Private key.  The
+   private key consists of 4 parameters:
 
    *  S: affine map from F^{m} to F^{m}
    *  T: affine map from F^{n} to F^{n}
@@ -2005,7 +2005,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
    The partial public key now consists of 5 submatrices totaling
    o1*o2*v1 + o1*o1*(o1+1)/2 +o1*o2*o1 + o1*o2*(o2+1)/2 + o2*o2*(o2+1)/2
-   elements of F.  Additionally the seed spub is 32 bytes.  The secret
+   elements of F.  Additionally the seed spub is 32 bytes.  The private
    key can also be stored as the seeds of the key generation process
    spriv (32 bytes) and spub (32 bytes).  This is denoted as the
    compressed key and has a size of total 64 bytes.  The resulting
@@ -2013,13 +2013,13 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                 [Page 36]
+Vredendaal, et al.      Expires 22 September 2022              [Page 36]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
    |=========================+==========+=========|
-   | Algorithm               | Public   | Secret  |
+   | Algorithm               | Public   | Private |
    |                         | Key      | Key     |
    |                         | Length   | Length  |
    |=========================+==========+=========+
@@ -2034,7 +2034,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
                                  Figure 16
 
-9.3.  Secret Key Full Encoding
+9.3.  Private key Full Encoding
 
    A Rainbow private key encoded according with PKCS#8 MUST include the
    following two fields:
@@ -2051,16 +2051,16 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
    RainbowPrivateKey ::= SEQUENCE {
        version    INTEGER {v0(0)}       -- version (round 3)
-       S          OCTET STRING,         -- map S
-       T          OCTET STRING,         -- map T
-       F          OCTET STRING,         -- map F
+       s          OCTET STRING,         -- map S
+       t          OCTET STRING,         -- map T
+       f          OCTET STRING,         -- map F
        ell        OCTET STRING,
-       PublicKey  [0] IMPLICIT RainbowPublicKey OPTIONAL
+       publicKey  [0] IMPLICIT RainbowPublicKey OPTIONAL
        -- see next section
    }
 
 
-9.4.  Secret Key Partial Encoding
+9.4.  Private key Partial Encoding
 
    A partially populated private key is used when Compressed Rainbow is
    used.  In this case, spriv and spub are used to regenerate the full
@@ -2069,9 +2069,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                 [Page 37]
+Vredendaal, et al.      Expires 22 September 2022              [Page 37]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
    RainbowPrivateKey ::= SEQUENCE {
@@ -2079,7 +2079,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
        s_priv     OCTET STRING,    -- seed for private key
        s_pub      OCTET STRING,    -- seed for public key
        ell        OCTET STRING,
-       PublicKey  [0] IMPLICIT RainbowPublicKey OPTIONAL
+       publicKey  [0] IMPLICIT RainbowPublicKey OPTIONAL
                                    -- see next section
    }
 
@@ -2102,7 +2102,7 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
    RainbowPublicKey ::= SEQUENCE {
        s_pub      OCTET STRING      -- (EMPTY)
-       P          OCTET STRING,
+       p          OCTET STRING,
        ell        OCTET STRING
    }
 
@@ -2125,9 +2125,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                 [Page 38]
+Vredendaal, et al.      Expires 22 September 2022              [Page 38]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
 12.  Security Considerations
@@ -2181,9 +2181,9 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                 [Page 39]
+Vredendaal, et al.      Expires 22 September 2022              [Page 39]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
    [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
@@ -2207,13 +2207,13 @@ Authors' Addresses
    Email: cvvrede@gmail.com
 
 
-   Silvio Dragione (editor)
+   Silvio Dragone (editor)
    IBM Research GmbH
    Saeumerstrasse 4
    CH-8803 Rueschlikon
    Switzerland
 
-   Email: sdi@zurich.ibm.com
+   Email: sid@zurich.ibm.com
 
 
    Basil Hess (editor)
@@ -2225,7 +2225,7 @@ Authors' Addresses
    Email: bhe@zurich.ibm.com
 
 
-   Tamas Visgrady (editor)
+   Tamas Visegrady (editor)
    IBM Research GmbH
    Saeumerstrasse 4
    CH-8803 Rueschlikon
@@ -2237,9 +2237,9 @@ Authors' Addresses
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                 [Page 40]
+Vredendaal, et al.      Expires 22 September 2022              [Page 40]
 
-Internet-Draft      QSC Cryptography Key Information       November 2021
+Internet-Draft      QSC Cryptography Key Information          March 2022
 
 
    Michael Osborne (editor)
@@ -2293,4 +2293,4 @@ Internet-Draft      QSC Cryptography Key Information       November 2021
 
 
 
-Vredendaal, et al.         Expires 13 May 2022                 [Page 41]
+Vredendaal, et al.      Expires 22 September 2022              [Page 41]

--- a/draft-uni-qsckeys.xml
+++ b/draft-uni-qsckeys.xml
@@ -598,7 +598,7 @@ SubjectPublicKeyInfo := SEQUENCE {
 
             </section>
             <section numbered="true" toc="default">
-                <name>Private key Full Encoding</name>
+                <name>Private Key Full Encoding</name>
 
                 <t>Distributing a Classic McEliece private key with PKCS#8 involves including: </t>
                 <ul spacing="compact">
@@ -780,7 +780,7 @@ McEliecePublicKey ::= SEQUENCE {
             </section>
 
             <section numbered="true" toc="default">
-                <name>Private key Full Encoding</name>
+                <name>Private Key Full Encoding</name>
 
                 <t>Distributing a Kyber private key with PKCS#8 requires:</t>
                 <ul spacing="compact">
@@ -973,7 +973,7 @@ KyberPublicKey ::= SEQUENCE {
 
             </section>
             <section numbered="true" toc="default">
-                <name>Private key Full Encoding</name>
+                <name>Private Key Full Encoding</name>
 
                 <t>An NTRU private key encoded according with PKCS#8 MUST include the following two fields:</t>
                 <ul spacing="compact">
@@ -1095,7 +1095,7 @@ NTRUPrivateKey ::= SEQUENCE {
 
             </section>
             <section numbered="true" toc="default">
-                <name>Private key Full Encoding</name>
+                <name>Private Key Full Encoding</name>
 
                 <t>A SABER private key encoded according with PKCS#8 MUST include the following two fields:</t>
                 <ul spacing="compact">
@@ -1314,7 +1314,7 @@ SABERPublicKey := SEQUENCE {
 
             </section>
             <section numbered="true" toc="default">
-                <name>Private key Full Encoding</name>
+                <name>Private Key Full Encoding</name>
                 <t>A Dilithium private key encoded according with PKCS#8 MUST include the following two fields:</t>
                 <ul spacing="compact">
                     <li>dilithium-(kxl)-r3 in the algorithm field of AlgorithmIdentifier</li>
@@ -1474,7 +1474,7 @@ DilithiumPublicKey ::= SEQUENCE {
 
             </section>
             <section numbered="true" toc="default">
-                <name>Private key Full Encoding</name>
+                <name>Private Key Full Encoding</name>
 
                 <t>Encoding a FALCON private key with PKCS#8 must include the following two fields: </t>
                 <ul spacing="compact">
@@ -1644,7 +1644,7 @@ FALCONPublicKey := SEQUENCE {
 
             </section>
             <section numbered="true" toc="default">
-                <name>Private key Full Encoding</name>
+                <name>Private Key Full Encoding</name>
 
                 <t>A Rainbow private key encoded according with PKCS#8 MUST include the following two fields: </t>
                 <ul spacing="compact">

--- a/draft-uni-qsckeys.xml
+++ b/draft-uni-qsckeys.xml
@@ -6,7 +6,7 @@ which is available here: http://xml.resource.org. -->
 <!-- used by XSLT processors --> 
 <!-- For a complete list and description of processing instructions (PIs), 
 please see http://xml.resource.org/authoring/README.html. -->
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="info" docName="draft-uni-qsckeys-00" ipr="trust200902" obsoletes="" updates="" submissionType="IETF" xml:lang="en" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" version="3">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="info" docName="draft-uni-qsckeys-01" ipr="trust200902" obsoletes="" updates="" submissionType="IETF" xml:lang="en" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" version="3">
     <!-- xml2rfc v2v3 conversion 2.38.1 -->
     <!-- category values: std, bcp, info, exp, and historic
     ipr values: trust200902, noModificationTrust200902, noDerivativesTrust200902,
@@ -21,7 +21,7 @@ please see http://xml.resource.org/authoring/README.html. -->
         full title is longer than 39 characters -->
 
         <title abbrev="QSC Cryptography Key Information"> Quantum Safe Cryptography Key Information</title>
-        <seriesInfo name="Individual-Draft" value="draft-uni-qsckeys-00" />
+        <seriesInfo name="Individual-Draft" value="draft-uni-qsckeys-01" />
         <!-- add 'role="editor"' below for the editors if appropriate -->
 
         <author fullname="Christine van Vredendaal" initials="C.v.V." role="editor" surname="Vredendaal">
@@ -42,7 +42,7 @@ please see http://xml.resource.org/authoring/README.html. -->
         </author>
         <!-- Another author who claims to be an editor -->
 
-        <author fullname="Silvio Dragione " initials="S.D." role="editor" surname="Dragone">
+        <author fullname="Silvio Dragone" initials="S.D." role="editor" surname="Dragone">
             <organization>IBM Research GmbH</organization>
             <address>
                 <postal>
@@ -54,7 +54,7 @@ please see http://xml.resource.org/authoring/README.html. -->
                     <code>8803</code>
                     <country>CH</country>
                 </postal>
-                <email>sdi@zurich.ibm.com</email>
+                <email>sid@zurich.ibm.com</email>
                 <!-- uri and facsimile elements may also be added -->
             </address>
         </author>
@@ -76,7 +76,7 @@ please see http://xml.resource.org/authoring/README.html. -->
             </address>
         </author>
 
-        <author fullname="Tamas Visgrady" initials="T.V." role="editor" surname="Visegrady">
+        <author fullname="Tamas Visegrady" initials="T.V." role="editor" surname="Visegrady">
             <organization>IBM Research GmbH</organization>
             <address>
                 <postal>
@@ -146,7 +146,7 @@ please see http://xml.resource.org/authoring/README.html. -->
         </author>
 
 
-        <date year="2021" />
+        <date year="2022" />
         <!-- If the month and year are both specified and are the current ones, xml2rfc will fill
         in the current day for you. If only the current year is specified, xml2rfc will fill
         in the current day and month for you. If the year is not the current one, it is
@@ -216,9 +216,9 @@ please see http://xml.resource.org/authoring/README.html. -->
                 </t>
                 <artwork align="left" name="" type="" alt="">
                     <![CDATA[
-AlgorithmIdentifier  ::=  SEQUENCE  {
-algorithm  OBJECT IDENTIFIER, - OID: algorithm and algo parameter 
-parameters pqcAlgorithmParameterName OPTIONAL
+AlgorithmIdentifier ::=  SEQUENCE {
+    algorithm  OBJECT IDENTIFIER, - OID: algorithm and algo parameter 
+    parameters pqcAlgorithmParameterName OPTIONAL
 }
 pqcAlgorithmParameterName ::= PrintableString
 ]]>
@@ -247,32 +247,32 @@ pqcAlgorithmParameterName ::= PrintableString
 | kyber-512-r3                                                  |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-kem-kyber kyber-512-r3 }           |
-|         |dot. | 1.3.6.1.4.1.2.267.8.2.2                       |
+|         |dot. |                                               |
 |---------+-----+-----------------------------------------------|
 | kyber-512-90s-r3                                              |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-kem-kyber kyber-512-90s-r3}        |
-|         |dot  | 1.3.6.1.4.1.2.267.10.2.2                      |
+|         |dot  |                                               |
 |---------------+-----+-----------------------------------------|
 | kyber-768-r3                                                  |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-kem-kyber kyber-768-r3 }           |
-|         |dot  | 1.3.6.1.4.1.2.267.8.3.3                       |
+|         |dot  |                                               |
 |---------------+-----+-----------------------------------------|
 | kyber-768-90s-r3                                              |
 |---------------+-----+-----------------------------------------|
 |         |ASN.1| {..*.. pqc-kem-kyber kyber-768-90s-r3 }       |
-|         |dot  | 1.3.6.1.4.1.2.267.10.3.3                      |
+|         |dot  |                                               |
 |---------+-----+-----------------------------------------------|
 | kyber-1024-r3                                                 |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-kem-kyber kyber-1024-r3 }          |
-|         |dot  | 1.3.6.1.4.1.2.267.8.4.4                       |
+|         |dot  |                                               |
 |---------+-----+-----------------------------------------------|
 | kyber-1024-90s-r3                                             |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-kem-kyber kyber-1024-90s-r3}       |
-|         |dot  | 1.3.6.1.4.1.2.267.10.4.4                      |
+|         |dot  |                                               |
 |=========+=====+===============================================|
 | NTRU (PQC KEM)                                                |
 |=========+=====+===============================================|
@@ -308,7 +308,7 @@ pqcAlgorithmParameterName ::= PrintableString
 | dilithium-4x4-r3                                              |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1|{..*.. pqc-ds-dilithium dilithium-4x4-r3}      |
-|         |dot  | 1.3.6.1.4.1.2.267.7.4.4                       |
+|         |dot  |                                               |
 |---------------+-----+-----------------------------------------|
 | dilithium-4x4-aes-r3                                          |
 |---------+-----+-----------------------------------------------|
@@ -318,7 +318,7 @@ pqcAlgorithmParameterName ::= PrintableString
 | dilithium-6x5-r3                                              |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-ds-dilithium dilithium-6x5-r3}     |
-|         | Dot | 1.3.6.1.4.1.2.267.7.6.5                       |
+|         | Dot |                                               |
 |---------+-----+-----------------------------------------------|
 | dilithium-6x5-aes-r3                                          |
 |---------+-----+-----------------------------------------------|
@@ -328,7 +328,7 @@ pqcAlgorithmParameterName ::= PrintableString
 | dilithium-8x7-r3                                              |
 |---------+-----+-----------------------------------------------|
 |         |ASN.1| {..*.. pqc-ds-dilithium dilithium-8x7-r3}     |
-|         |Dot  | 1.3.6.1.4.1.2.267.7.8.7                       |
+|         |Dot  |                                               |
 |---------+-----+-----------------------------------------------|
 | dilithium-8x7-aes-r3                                          |
 |---------+-----+-----------------------------------------------|
@@ -361,7 +361,7 @@ pqcAlgorithmParameterName ::= PrintableString
             <section numbered="true" toc="default">
                 <name>Key Formats</name>
                 <t>
-                    The Secret Key Format defined is from PKCS#8
+                    The private key format defined is from PKCS#8
                     <xref target="RFC5208" format="default"></xref>
                     .
                     PKCS#8 PrivateKeyInfo is defined as:
@@ -381,13 +381,13 @@ PrivateKeyInfo ::=  SEQUENCE {
             <section numbered="true" toc="default">
                 <name>
                     Public Key Format based on
-                    <xref target="RFC5480" format="default"></xref>
+                    <xref target="RFC5280" format="default"></xref>
                 </name>
 
-                <t>RFC5480 subjectPublicKeyInfo is defined in as:</t>
+                <t>RFC5280 subjectPublicKeyInfo is defined in as:</t>
                 <artwork align="left" name="" type="" alt="">
                     <![CDATA[
-subjectPublicKeyInfo := SEQUENCE {
+SubjectPublicKeyInfo := SEQUENCE {
     algorithm          AlgorithmIdentifier  -- see chapter above
     subjectPublicKey   BIT STRING           -- see chapter below
 }
@@ -558,10 +558,12 @@ subjectPublicKeyInfo := SEQUENCE {
             <section numbered="true" toc="default">
                 <name>Key Details</name>
 
-                <t>Public key. The public-key consists of 
-            * T: mt x k matrix
-            Each row of T is represented as a ceiling(k/8)-byte string, and the public key is represented as the mt*ceiling(k/8)-byte concatenation of these strings.
-            Secret key. The secret key consists of five parameters:</t>
+                <t>Public key. The public-key consists of</t>
+                    <ul spacing="compact">
+                        <li>T: mt x k matrix</li>
+                    </ul>
+            <t>Each row of T is represented as a ceiling(k/8)-byte string, and the public key is represented as the mt*ceiling(k/8)-byte concatenation of these strings.
+            Private key. The private key consists of five parameters:</t>
                 <ul spacing="compact">
                     <li>delta: nonce</li>
                     <li>C    : column selections</li>
@@ -569,14 +571,14 @@ subjectPublicKeyInfo := SEQUENCE {
                     <li>alpha: field orderings</li>
                     <li>s    : uniform random n-bit string</li>
                 </ul>
-                <t>The size necessary to hold all secret key elements accounts to ceiling(l / 8) + [ceiling(nu / 8) | 8] + ceiling(m / 8) + ceiling((2*m - 1) * 2*m - 4) + ceiling(n / 8) bytes.
+                <t>The size necessary to hold all private key elements accounts to ceiling(l / 8) + [ceiling(nu / 8) | 8] + ceiling(m / 8) + ceiling((2*m - 1) * 2*m - 4) + ceiling(n / 8) bytes.
             The resulting public key and private key sizes can be found in the table below.</t>
                 <figure anchor="McElieceKeySizes">
                     <artwork align="left" name="" type="" alt="">
                         <![CDATA[
 |=====================+=================+================|
 | Parameter Set.      | Size of the     | Size of the    |
-|                     | public key      | secret key     |
+|                     | public key      | private key    |
 |                     | in bytes.       | in bytes       |
 |=====================+=================+================|
 | mceliece348864-r3   |       261120    |       6492     |
@@ -596,7 +598,7 @@ subjectPublicKeyInfo := SEQUENCE {
 
             </section>
             <section numbered="true" toc="default">
-                <name>Secret Key Full Encoding</name>
+                <name>Private key Full Encoding</name>
 
                 <t>Distributing a Classic McEliece private key with PKCS#8 involves including: </t>
                 <ul spacing="compact">
@@ -608,13 +610,13 @@ subjectPublicKeyInfo := SEQUENCE {
                 <artwork align="left" name="" type="" alt="">
                     <![CDATA[
 McEliecePrivateKey ::= SEQUENCE {
-    Version    INTEGER {v0(0)} -- version (round 3)
+    version    INTEGER {v0(0)} -- version (round 3)
     delta      OCTET STRING,   -- nonce
     C          OCTET STRING,   -- column selections
     g          OCTET STRING,   -- monic irreducible polynomial
     alpha      OCTET STRING,   -- field orderings
     s          OCTET STRING,   -- random n-bit string
-    PublicKey  [0] IMPLICIT McEliecePublicKey OPTIONAL 
+    publicKey  [0] IMPLICIT McEliecePublicKey OPTIONAL 
                                 -- see next section
 }
 ]]>
@@ -624,8 +626,7 @@ McEliecePrivateKey ::= SEQUENCE {
                 <name>Public Key Full Encoding</name>
                 <artwork align="left" name="" type="" alt="">
                     <![CDATA[
-Classic McEliece Public Key Format  
-    McEliecePublicKey ::= SEQUENCE {
+McEliecePublicKey ::= SEQUENCE {
     T       OCTET STRING    -- public key
 }
 ]]>
@@ -656,8 +657,8 @@ Classic McEliece Public Key Format
 | Parameters              | n= 256,                             |
 |                         | k=2                                 |
 |                         | q=3329                              |
-|                         | nu_1=3                              |
-|                         | nu_2=2                              |
+|                         | eta_1=3                             |
+|                         | eta_2=2                             |
 |                         | (d_u, d_v)=(10, 4)                  |
 |                         | delta=2^{-139}                      |
 |=========================+=====================================|
@@ -670,8 +671,8 @@ Classic McEliece Public Key Format
 | Parameters              | n= 256,                             |
 |                         | k=2                                 |
 |                         | q=3329                              |
-|                         | nu_1=3                              |
-|                         | nu_2=2                              |
+|                         | eta_1=3                             |
+|                         | eta_2=2                             |
 |                         | (d_u, d_v)=(10, 4)                  |
 |                         | delta=2^{-139}                      |
 |=========================+=====================================|
@@ -684,8 +685,8 @@ Classic McEliece Public Key Format
 | Parameters              | n= 256,                             |
 |                         | k=3                                 |
 |                         | q=3329                              |
-|                         | nu_1=2                              |
-|                         | nu_2=2                              |
+|                         | eta_1=2                             |
+|                         | eta_2=2                             |
 |                         | (d_u, d_v)=(10, 4)                  |
 |                         | delta=2^{-164}                      |
 |=========================+=====================================|
@@ -698,8 +699,8 @@ Classic McEliece Public Key Format
 | Parameters              | n= 256,                             |
 |                         | k=3                                 |
 |                         | q=3329                              |
-|                         | nu_1=2                              |
-|                         | nu_2=2                              |
+|                         | eta_1=2                             |
+|                         | eta_2=2                             |
 |                         | (d_u, d_v)=(10, 4)                  |
 |                         | delta=2^{-164}                      |
 |=========================+=====================================|
@@ -712,8 +713,8 @@ Classic McEliece Public Key Format
 | Parameters              | n= 256,                             |
 |                         | k=4                                 |
 |                         | q=3329                              |
-|                         | nu_1=2                              |
-|                         | nu_2=2                              |
+|                         | eta_1=2                             |
+|                         | eta_2=2                             |
 |                         | (d_u, d_v)=(11, 5)                  |
 |                         | delta=2^{-174}                      |
 |=========================+=====================================|
@@ -726,8 +727,8 @@ Classic McEliece Public Key Format
 | Parameters              | n= 256,                             |
 |                         | k=4                                 |
 |                         | q=3329                              |
-|                         | nu_1=2                              |
-|                         | nu_2=2                              |
+|                         | eta_1=2                             |
+|                         | eta_2=2                             |
 |                         | (d_u, d_v)=(11, 5)                  |
 |                         | delta=2^{-174}                      |
 |=========================+=====================================|
@@ -747,31 +748,31 @@ Classic McEliece Public Key Format
                 </ul>
                 <t>The size necessary to hold all public key elements is 12*k*n/8+32 bytes.
                     
-                    Secret key. The secret key consists of 3 parameters:</t>
+                    Private key. The private key consists of 3 parameters:</t>
                 <ul spacing="compact">
-                    <li>s: encoded sample from a centered binomial distribution B_nu1 (12*k*n/8 bytes)</li>
-                    <li>z: a nonce (32 bytes)</li>
+                    <li>s: encoded sample from a centered binomial distribution B_{eta_1} (12*k*n/8 bytes)</li>
                     <li>H(pk): hashed public key (32 bytes). Kyber uses SHA3-256 as H by default. The '90s' variants use SHA256 instead.</li>
+                    <li>z: a nonce (32 bytes)</li>
                 </ul>
-                <t>If the secret key is fully populated, it consists of 3 parameters. The size necessary to hold all secret key elements accounts to 12*k*n/8+64 bytes, not counting the optional public key.
+                <t>If the private key is fully populated, it consists of 3 parameters. The size necessary to hold all private key elements accounts to 12*k*n/8+64 bytes, not counting the optional public key.
                     The resulting public key and private key sizes are shown in the following table.</t>
                 <figure anchor="KyberKeyLengths">
                     <artwork align="left" name="" type="" alt="">
                         <![CDATA[
-|==========================+=========+==========+=========|
-| Algorithm OID            | Public  |   Secret |  Secret |
-|                          | Key     |   Key    |  Key    |
-|                          |         |          |(partial)|
-|==========================+=========+==========+=========|
-| kyber512-r3 /            |   800   |   832    |    32   |
-| kyber512-90s-r3          |         |          |         |
-|--------------------------|---------|----------|---------|
-| kyber768-r3 /            |  1184   |   1216   |    32   |
-| kyber768-90s-r3          |         |          |         |
-|--------------------------|--------------------|---------|
-| kyber1024-r3 /           |  1568   |   1600   |    32   |
-| kyber1024-90s-r3         |         |          |         |
-|==========================+=========+==========+=========|
+|==========================+=========+==========+===========|
+| Algorithm OID            | Public  |   Private |  Private |
+|                          | Key     |   Key    |  Key      |
+|                          |         |          |(partial)  |
+|==========================+=========+==========+===========|
+| kyber512-r3 /            |   800   |   832    |    32     |
+| kyber512-90s-r3          |         |          |           |
+|--------------------------|---------|----------|-----------|
+| kyber768-r3 /            |  1184   |   1216   |    32     |
+| kyber768-90s-r3          |         |          |           |
+|--------------------------|--------------------|-----------|
+| kyber1024-r3 /           |  1568   |   1600   |    32     |
+| kyber1024-90s-r3         |         |          |           |
+|==========================+=========+==========+===========|
 ]]>
                     </artwork>
                 </figure>
@@ -779,7 +780,7 @@ Classic McEliece Public Key Format
             </section>
 
             <section numbered="true" toc="default">
-                <name>Secret Key Full Encoding</name>
+                <name>Private key Full Encoding</name>
 
                 <t>Distributing a Kyber private key with PKCS#8 requires:</t>
                 <ul spacing="compact">
@@ -791,19 +792,19 @@ Classic McEliece Public Key Format
                 <artwork name="" type="" align="left" alt="">
                     <![CDATA[
 KyberPrivateKey ::= SEQUENCE {
-    Version     INTEGER {v0(0)}   -- version (round 3)
-    nonce       OCTET STRING,     -- z
+    version     INTEGER {v0(0)}   -- version (round 3)
     s           OCTET STRING,     -- sample s
-    PublicKey   [0] IMPLICIT KyberPublicKey OPTIONAL,
+    publicKey   [0] IMPLICIT KyberPublicKey OPTIONAL,
                                   -- see next section
     hpk         OCTET STRING      -- H(pk)
+    nonce       OCTET STRING,     -- z
 }
 ]]>
                 </artwork>
             </section>
 
             <section numbered="true" toc="default">
-                <name>Secret Key Partial Encoding </name>
+                <name>Private key Partial Encoding</name>
 
                 <t>The partially populated parameter set uses of the fact that some parameters can be regenerated. In this case, only the initial seed 'd' (nonce) is stored and used to regenerate the full key.  
                     Partially encoded keys use the same ASN.1 structure as the fully polulated keys, simply with the regenerated fields set to EMPTY. 
@@ -814,11 +815,11 @@ KyberPrivateKey ::= SEQUENCE {
                     <![CDATA[
 KyberPrivateKey ::= SEQUENCE {
     version     INTEGER {v0(0)}   -- version (round 3)
-    nonce       OCTET STRING,     -- d
     s           OCTET STRING,     -- EMPTY
-    PublicKey   [0] IMPLICIT KyberPublicKey OPTIONAL,
+    publicKey   [0] IMPLICIT KyberPublicKey OPTIONAL,
                                   -- see next section
     hpk         OCTET STRING      -- EMPTY
+    nonce       OCTET STRING,     -- d
 }
 ]]>
                 </artwork>
@@ -862,10 +863,10 @@ KyberPublicKey ::= SEQUENCE {
 | NIST Level Security     | Level 1                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Dimension/Degree n= 509             |
-|                         | Polynomial  Phin= (xn - 1)/(x-1     |
+|                         | Polynomial  Phin=(x^n - 1)/(x-1)    |
 |                         | Polynomial  Phi1=(x-1)              |
 |                         | Modulus p=3                         |
-|                         | Modulus q= 2048                     |
+|                         | Modulus q=2048                      |
 |=========================+=====================================|
 | ntruhps2048677-r3                                             |
 |=========================+=====================================|
@@ -873,11 +874,11 @@ KyberPublicKey ::= SEQUENCE {
 |                         | <.  >                               |
 | NIST Level Security     | Level 3 (1) see spec.               |
 |-------------------------|-------------------------------------|
-| Parameters              | Dimension/Degree n= 677             |
-|                         | Polynomial  Phin= (xn - 1)/(x-1)    |
+| Parameters              | Dimension/Degree n=677              |
+|                         | Polynomial  Phin=(x^n - 1)/(x-1)    |
 |                         | Polynomial  Phi1=(x-1)              |
 |                         | Modulus p=3                         |
-|                         | Modulus q= 2048                     |
+|                         | Modulus q=2048                      |
 |=========================+=====================================|
 | ntruhps4096821-r3                                             |
 |=========================+=====================================|
@@ -886,7 +887,7 @@ KyberPublicKey ::= SEQUENCE {
 | NIST Level Security     | Level 3 (1) see spec.               |
 |-------------------------|-------------------------------------|
 | Parameters              | Dimension/Degree n= 821             |
-|                         | Polynomial  Phin= (xn - 1)/(x-1)    |
+|                         | Polynomial  Phin=(x^n - 1)/(x-1)    |
 |                         | Polynomial  Phi1=(x-1)              |
 |                         | Modulus p=3                         |
 |                         | Modulus q= 4096                     |
@@ -898,10 +899,10 @@ KyberPublicKey ::= SEQUENCE {
 | NIST Level Security     | Level 5 (3)  see spec.              |
 |-------------------------|-------------------------------------|
 | Parameters              | Dimension/Degree n= 701             |
-|                         | Polynomial  Phin= (xn - 1)/(x-1)    |
+|                         | Polynomial  Phin= (x^n - 1)/(x-1)   |
 |                         | Polynomial  Phi1=(x-1)              |
 |                         | Modulus p=3                         |
-|                         | Modulus q= 8192                     |
+|                         | Modulus q=8192                      |
 |=========================+=====================================|
 ]]>
                     </artwork>
@@ -913,25 +914,25 @@ KyberPublicKey ::= SEQUENCE {
                 <name>Key Details</name>
                 <t>Public key. The public-key consists of a single parameter :</t>
                 <ul spacing="compact">
-                    <li>a polynomial h that satisfies h?f=3?g in the ring Rq=Z[x]/(q, Phi1?Phin).</li>
+                    <li>a polynomial h that satisfies h*f=3*g in the ring Rq=Z[x]/(q, Phi_1*Phi_n).</li>
                 </ul>
-                <t>This means there are n - 1 coefficients of size at most q in the public key, and the size necessary to store the polynomial is therefore is ceiling((n - 1)?log2(q)/8) bytes. The resulting sizes for the parameter sets can be found in the Table below.
-                    Secret key. The secret key consists of 4 parameters:</t>
+                <t>This means there are n - 1 coefficients of size at most q in the public key, and the size necessary to store the polynomial is therefore is ceiling((n - 1)*log2(q)/8) bytes. The resulting sizes for the parameter sets can be found in the Table below.
+                    Private key. The private key consists of 4 parameters:</t>
                 <ul spacing="compact">
-                    <li>a polynomial f that is a ternary (coefficients fi are in {-1, 0, 1}) polynomial of degree n - 2, with the additional property that ∑_(i=0)^(n-3)  f_i?? f?_(i+1)≥0, </li>
-                    <li>a polynomial fp that satisfies f?fp=1 in the ring Rq=Z[x]/(3, Phin),</li>
-                    <li>a polynomial hq that satisfies h?hq=1 in the ring Rq=Z[x]/(q, Phin), and </li>
+                    <li>a polynomial f that is a ternary (coefficients fi are in {-1, 0, 1}) polynomial of degree n - 2, with the additional property that ∑_(i=0)^{n-3}  f_i*f_{i+1}≥0, </li>
+                    <li>a polynomial f_p that satisfies f*f_p=1 in the ring Rq=Z[x]/(3, Phi_n),</li>
+                    <li>a polynomial h_q that satisfies h*h_q=1 in the ring Rq=Z[x]/(q, Phi_n), and </li>
                     <li>a seed=fg_bits || prf_key=f_bits ||  g_bits || prf_key containing the randomness for the key sampling and the implicit rejection mechanism. Optionally implementers may expand this from a 32-byte seed.</li>
                 </ul>
-                <t>This means there are 2 polynomials, f and fp, having n - 1 coefficients with absolute value at most 1 in the secret key. For these polynomials, the packing algorithm in Section 1.8.7 of the Specification allows to pack 5 coefficients in a byte, so the storage requirement to store each is ceiling((n - 1)/5) bytes. Additionally hq is part of the secret key, which requires the same storage size as that of the public key h, i.e. ceiling((n - 1)?log2(q)/8) bytes. For the seed bytes, the specification recommends:</t>
+                <t>This means there are 2 polynomials, f and fp, having n - 1 coefficients with absolute value at most 1 in the private key. For these polynomials, the packing algorithm in Section 1.8.7 of the Specification allows to pack 5 coefficients in a byte, so the storage requirement to store each is ceiling((n - 1)/5) bytes. Additionally hq is part of the private key, which requires the same storage size as that of the public key h, i.e. ceiling((n - 1)*log2(q)/8) bytes. For the seed bytes, the specification recommends:</t>
                 <ul spacing="compact">
                     <li>>f_bits having n - 1 bytes, </li>
-                    <li>>g_bits having n - 1 bytes for ntruhrss701, ceiling(30/8?(n-1)) bytes for the other parameter sets, </li>
+                    <li>>g_bits having n - 1 bytes for ntruhrss701, ceiling(30/8*(n-1)) bytes for the other parameter sets, </li>
                     <li>prf_key having 32 bytes.</li>
                 </ul>
                 <t>Implementers may choose to expand the seed from one 32-byte seed.
                     The resulting sizes for the parameter sets can be found in the Table below. Where the seed expansion is omitted, the 32-byte seed must be replaced by key_seed_bits=sample_key_bits+prf_key_bits. The impact of these options are indicated as 32-byte seed/expanded seed in the Table below.
-                    Parameter Set    Size of the public key in bytes    Size of the secret key in bytes</t>
+                    Parameter Set    Size of the public key in bytes    Size of the private key in bytes</t>
                 <figure anchor="NTRUOIDs">
                     <artwork align="left" name="" type="" alt="">
                         <![CDATA[
@@ -940,31 +941,31 @@ KyberPublicKey ::= SEQUENCE {
 |---------------------|------------------------------|
 | Public Key (Bytes)  | 699                          |
 | seed/expanded seed  | 935 / 3348                   |
-| f,fp,hq,seed        | 102,102,699,32/2445          |
+| f,f_p,h_q,seed      | 102,102,699,32/2445          |
 |=====================+==============================|
 | ntruhps2048677-r3                                  |
 |---------------------|------------------------------|
 | Public Key (Bytes)  | 699                          |
 | seed/expanded seed  | 935 / 3348                   |
-| f,fp,hq,seed        | 102,102,699,32/2445          |
+| f,f_p,h_q,seed      | 102,102,699,32/2445          |
 |=====================+==============================|
 | ntruhps2048677-r3                                  |
 |---------------------|------------------------------|
-| Public Key (Bytes)  |    930                          |
+| Public Key (Bytes)  |    930                       |
 | seed/expanded seed  | 1234 / 4445                  |
-| (f,fp,hq,seed)      | 136,136,930,32/3243          |
+| (f,f_p,h_q,seed)    | 136,136,930,32/3243          |
 |=====================+==============================|
 | ntruhps4096821-r3                                  |
 |---------------------|------------------------------|
 | Public Key (Bytes)  | 1230                         |
 | seed/expanded seed  | 1590 / 5485                  |
-| (f,fp,hq,seed)      | 164,164,1230,32/3927         |
+| (f,f_p,h_q,seed)    | 164,164,1230,32/3927         |
 |=====================+==============================|
 | ntruhrss701-r3                                     |
 |---------------------|------------------------------|
 | Public Key (Bytes)  | 1138                         |
 | seed/expanded seed  | 1450 / 2850                  |
-| (f,fp,hq,seed)      | 140,140,1138,32/1432         |
+| (f,f_p,h_q,seed)    | 140,140,1138,32/1432         |
 |=====================+==============================|
 ]]>
                     </artwork>
@@ -972,7 +973,7 @@ KyberPublicKey ::= SEQUENCE {
 
             </section>
             <section numbered="true" toc="default">
-                <name>Secret Key Full Encoding</name>
+                <name>Private key Full Encoding</name>
 
                 <t>An NTRU private key encoded according with PKCS#8 MUST include the following two fields:</t>
                 <ul spacing="compact">
@@ -980,7 +981,7 @@ KyberPublicKey ::= SEQUENCE {
                     <li>NTRUPrivateKey in the privateKey field, which is an OCTET STRING.</li>
                 </ul>
                 <t>When a NTRU public key is included in the distributed PrivateKeyInfo, the PublicKey field in NTRUPrivateKey is used (see description of NTRUPublicKey below).
-                    An NTRU secret key contains f, fp and hq, as well as a seed. The octet string format indicates the length of the string to follow, and indicates whether the seed or expanded seed is used.</t>
+                    An NTRU private key contains f, f_p and h_q, as well as a seed. The octet string format indicates the length of the string to follow, and indicates whether the seed or expanded seed is used.</t>
                 <artwork name="" type="" align="left" alt="">
                     <![CDATA[
 NTRUPrivateKey ::= SEQUENCE {
@@ -989,7 +990,7 @@ NTRUPrivateKey ::= SEQUENCE {
     fp         OCTET STRING,      -- short integer polynomial gp
     hq         OCTET STRING,      -- mod q integer polynomial hq
     seed       OCTET STRING,      -- fg_bits/prf_bits (or their seed)
-    PublicKey [0] IMPLICIT NTRUPublicKey OPTIONAL -- see next section
+    publicKey [0] IMPLICIT NTRUPublicKey OPTIONAL -- see next section
 }
 ]]>
                 </artwork>
@@ -998,7 +999,7 @@ NTRUPrivateKey ::= SEQUENCE {
             <section numbered="true" toc="default">
                 <name>Public Key Full Encoding</name>
 
-                <t>From the NTRU specification, the public key contains h. Each coefficient of h is encoded as an ? bit sequence, where ?=ceiling((n - 1)?log2(q)). Coefficients are then concatenated (two's complement, big endian convention). The final bit string is zero padded to fit into a byte sequence.
+                <t>From the NTRU specification, the public key contains h. Each coefficient of h is encoded as an l bit sequence, where l=ceiling((n - 1)*log2(q)). Coefficients are then concatenated (two's complement, big endian convention). The final bit string is zero padded to fit into a byte sequence.
                     NTRUPublicKey := SEQUENCE {
                     h          OCTET STRING  -- integer polynomial h
                     }</t>
@@ -1027,7 +1028,7 @@ NTRUPrivateKey ::= SEQUENCE {
 | NIST Level Security     | Level 1                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Degree n= 256                       |
-|                         | rank of the module ?= 2             |
+|                         | rank of the module l=2              |
 |                         | binomial distribution with u=10     |
 |                         | Modulus q=2^{13} and p=2^{10}       |
 |=========================+=====================================|
@@ -1038,7 +1039,7 @@ NTRUPrivateKey ::= SEQUENCE {
 | NIST Level Security     | Level 3                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Degree n= 256                       |
-|                         | rank of the module ?= 3             |
+|                         | rank of the module l=3              |
 |                         | binomial distribution with u=8      |
 |                         | Modulus q=2^{13} and p=2^{10}       |
 |=========================+=====================================|
@@ -1049,7 +1050,7 @@ NTRUPrivateKey ::= SEQUENCE {
 | NIST Level Security     | Level 5                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Degree n= 256                       |
-|                         | rank of the module ?= 4             |
+|                         | rank of the module l=4              |
 |                         | binomial distribution with u=6      |
 |                         | Modulus q=2^{13} and p=2^{10}       |
 |=========================+=====================================|
@@ -1057,7 +1058,7 @@ NTRUPrivateKey ::= SEQUENCE {
                     </artwork>
                 </figure>
 
-                <t>The rank of the module is denoted ? and differs per parameter set.</t>
+                <t>The rank of the module is denoted l and differs per parameter set.</t>
 
             </section>
             <section numbered="true" toc="default">
@@ -1067,34 +1068,34 @@ NTRUPrivateKey ::= SEQUENCE {
                     <li>>seed_A: public seed (32 bytes)</li>
                     <li>polynomials of degree 256 with 10-bit integer coefficients denoted by vector b.</li>
                 </ul>
-                <t>This means the size of the public key can be stored using ?*256*10+256 bits. The size of the public key as used in the three parameter sets can be found in the Table below.</t>
+                <t>This means the size of the public key can be stored using l*256*10+256 bits. The size of the public key as used in the three parameter sets can be found in the Table below.</t>
 
-                <t>Secret key. The secret key s consists of three parameters:</t>
+                <t>Private key. The private key s consists of three parameters:</t>
                 <ul spacing="compact">
                     <li>a 256-bit uniform random value z</li>
-                    <li> ? polynomials of degree 256 with 13-bit integer coefficients denoted by s</li>
+                    <li>l polynomials of degree 256 with 13-bit integer coefficients denoted by s</li>
                     <li>H(pk): hashed public key (32 bytes)</li>
                 </ul>
-                <t>This means the secret key can be stored using 512+?*256*13 bits. The size of the secret key as used in the three parameter sets can be found in the Table below.</t>
+                <t>This means the private key can be stored using 512+l*256*13 bits. The size of the private key as used in the three parameter sets can be found in the Table below.</t>
                 <figure anchor="SABERKeySizes">
                     <artwork align="left" name="" type="" alt="">
                         <![CDATA[
-|==========================+=========+==========|
-| Algorithm                | Public  |   Secret |
-|                          | Key     |   Key    |
-|                          | Length  |   Length |
-|==========================+=========+==========+
-| LightSaber-r3            |    672  |    896   |
-| Saber-r3                 |    992  |   1312   |
-| FireSaber-r3             |   1312  |   1728   |
-|==========================+=========+==========|
+|==========================+=========+===========|
+| Algorithm                | Public  |   Private |
+|                          | Key     |   Key     |
+|                          | Length  |   Length  |
+|==========================+=========+===========+
+| LightSaber-r3            |    672  |    896    |
+| Saber-r3                 |    992  |   1312    |
+| FireSaber-r3             |   1312  |   1728    |
+|==========================+=========+===========|
 ]]>
                     </artwork>
                 </figure>
 
             </section>
             <section numbered="true" toc="default">
-                <name>Secret Key Full Encoding</name>
+                <name>Private key Full Encoding</name>
 
                 <t>A SABER private key encoded according with PKCS#8 MUST include the following two fields:</t>
                 <ul spacing="compact">
@@ -1108,7 +1109,7 @@ SABERPrivateKey ::= SEQUENCE {
     version     INTEGER  {v0(0)}    -- version (round 3)
     z           OCTET STRING,       -- 32-byte random value z
     s           OCTET STRING,       -- short integer polynomial s
-    PublicKey   [0] IMPLICIT SABERPublicKey OPTIONAL,
+    publicKey   [0] IMPLICIT SABERPublicKey OPTIONAL,
                                     -- see next section
     hpk         OCTET STRING        -- H(pk)
 }
@@ -1134,8 +1135,8 @@ SABERPublicKey := SEQUENCE {
             <name>CRYSTALS-DILITHIUM</name>
 
             <t>Dilithium is a digital signature scheme that is based on the hardness of lattice problems over module lattices.
-                Project Website:    https://pq-crystals.org/dilithium/index.shtml
-                NIST Round 3 Submission (version 3.1):    https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+                Project Website: https://pq-crystals.org/dilithium/index.shtml
+                NIST Round 3 Submission (version 3.1): https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
                 https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf</t>
 
             <section numbered="true" toc="default">
@@ -1152,8 +1153,8 @@ SABERPublicKey := SEQUENCE {
 |                         | 1.3.6.1.4.1.2.267.7.4.4             |
 | NIST Level Security     | Level 2                             |
 |-------------------------|-------------------------------------|
-| Parameters              | Polynomial Ring Zq[x]/( x^n +1)     |
-|                         | Dimension/Degree n= 256             |
+| Parameters              | Polynomial Ring Zq[x]/( x^n+1 )     |
+|                         | Dimension/Degree n=256              |
 |                         | Modulus q=8380417                   |
 |                         | Dropped bits from t: d=13           |
 |                         | # of +-1's in c: tau=39             |
@@ -1161,7 +1162,7 @@ SABERPublicKey := SEQUENCE {
 |                         | gamma coefficient range: gamma1=2^17|
 |                         | low-order rounding range: gamma2=(q-|
 |                         | 1)/88                               |
-|                         | Secret Key Range (nu)=2             |
+|                         | Private key Range eta=2             |
 |                         | Dimensions of A: (k,l)=(4,4)        |
 |                         | Max # of 1's in the hint h: w=80    |
 |                         | Repetitions=4.25                    |
@@ -1173,7 +1174,7 @@ SABERPublicKey := SEQUENCE {
 | NIST Level Security     | Level 2                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
-|                         | Dimension/Degree n= 256             |
+|                         | Dimension/Degree n=256              |
 |                         | Modulus q=8380417                   |
 |                         | Dropped bits from t: d=13           |
 |                         | # of +-1's in c: tau=39             |
@@ -1181,7 +1182,7 @@ SABERPublicKey := SEQUENCE {
 |                         | y coefficient range: gamma1=2^17    |
 |                         | low-order rounding range:gamma2=(q- |
 |                         | -1)/88                              |
-|                         | Secret Key Range (nu)=2             |
+|                         | Private key Range eta=2             |
 |                         | Dimensions of A: (k,l)=(4,4)        |
 |                         | Max # of 1's in the hint h: w=80    |
 |                         | Repetitions=4.25                    |
@@ -1193,15 +1194,15 @@ SABERPublicKey := SEQUENCE {
 | NIST Level Security     | Level 3                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
-|                         | Dimension/Degree n= 256             |
+|                         | Dimension/Degree n=256              |
 |                         | Modulus q=8380417                   |
 |                         | Dropped bits from t: d=13           |
-|                         | # of +-1's in c: ?=49               |
+|                         | # of +-1's in c: tau=49             |
 |                         | challenge entropy=225               |
 |                         | y coefficient range: gamma1=2^19    |
 |                         | low-order rounding range:gamma2=(q- |
 |                         | -1)/32                              |
-|                         | Secret Key Range (nu)=4             |
+|                         | Private key Range eta=4             |
 |                         | Dimensions of A: (k,l)=(6,5)        |
 |                         | Max # of 1's in the hint h: w=55    |
 |                         | Repetitions=5.1                     |
@@ -1213,7 +1214,7 @@ SABERPublicKey := SEQUENCE {
 | NIST Level Security     | Level 3                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Polynomial Ring Zq[x]/( x^n +1 )    |
-|                         | Dimension/Degree n= 256             |
+|                         | Dimension/Degree n=256              |
 |                         | Modulus q=8380417                   |
 |                         | Dropped bits from t: d=13           |
 |                         | # of +-1's in c: tau=49             |
@@ -1221,7 +1222,7 @@ SABERPublicKey := SEQUENCE {
 |                         | y coefficient range: gamma1=2^19    |
 |                         | low-order rounding range:gamma2=(q- |
 |                         | -1)/32                              |
-|                         | Secret Key Range (nu)=4             |
+|                         | Private key Range eta=4             |
 |                         | Dimensions of A: (k,l)=(6,5)        |
 |                         | Max # of 1's in the hint h: w=55    |
 |                         | Repetitions=5.1                     |
@@ -1233,15 +1234,15 @@ SABERPublicKey := SEQUENCE {
 | NIST Level Security     | Level 5                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
-|                         | Dimension/Degree n= 256             |
+|                         | Dimension/Degree n=256              |
 |                         | Modulus q=8380417                   |
 |                         | Dropped bits from t: d=13           |
 |                         | # of +-1's in c: tau=60             |
 |                         | challenge entropy=257               |
-|                         | y coefficient range: ?1=2^19        |
+|                         | y coefficient range: gamma1=2^19    |
 |                         | low-order rounding range:gamma2=(q- |
 |                         | -1)/32                              |
-|                         | Secret Key Range (nu)=2             |
+|                         | Private key Range eta=2             |
 |                         | Dimensions of A: (k,l)=(8,7)        |
 |                         | Max # of 1's in the hint h: w=75    |
 |                         | Repetitions=3.85                    |
@@ -1253,7 +1254,7 @@ SABERPublicKey := SEQUENCE {
 | NIST Level Security     | Level 5                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Polynomial Ring Zq[x]/( x^n + 1 )   |
-|                         | Dimension/Degree n= 256             |
+|                         | Dimension/Degree n=256              |
 |                         | Modulus q=8380417                   |
 |                         | Dropped bits from t: d=13           |
 |                         | # of +-1's in c: tau=60             |
@@ -1261,7 +1262,7 @@ SABERPublicKey := SEQUENCE {
 |                         | y coefficient range: gamma1=2^19    |
 |                         | low-order rounding range:gamma2=(q- |
 |                         | -1)/32                              |
-|                         | Secret Key Range (nu)=2             |
+|                         | Private key Range eta=2             |
 |                         | Dimensions of A: (k,l)=(8,7)        |
 |                         | Max # of 1's in the hint h: w=75    |
 |                         | Repetitions=3.85                    |
@@ -1281,7 +1282,7 @@ SABERPublicKey := SEQUENCE {
                     <li>t1:  a vector encoded in 320*k bytes</li>
                 </ul>
                 <t>The size necessary to hold all public key elements accounts to 32+320*k bytes.</t>
-                <t>Secret key. The secret key consists of 6 parameters:</t>
+                <t>Private key. The private key consists of 6 parameters:</t>
                 <ul spacing="compact">
                     <li>rho: nonce </li>
                     <li>K: a key/seed/D</li>
@@ -1290,30 +1291,30 @@ SABERPublicKey := SEQUENCE {
                     <li>s2: vector (K)</li>
                     <li>t0: k polynomials</li>
                 </ul>
-                <t>If the secret key is fully populated, it consists of 6 parameters. The size necessary to hold all secret key elements accounts to 32+32+32+32*[(k+l)*ceiling(log(2*nu+1))+13*k] bytes.
+                <t>If the private key is fully populated, it consists of 6 parameters. The size necessary to hold all private key elements accounts to 32+32+32+32*[(k+l)*ceiling(log(2*eta+1))+13*k] bytes.
                     The resulting public key and private key sizes can be found in the table below.</t>
                 <figure anchor="DilithiumKeySizes">
                     <artwork align="left" name="" type="" alt="">
                         <![CDATA[
-|=========================+========+========+=========+=========|
-| Algorithm               | Public | Secret | Partial | Partial |
-|                         | Key    | Key SK | SK (V1) | SK (V2) |
-|                         | Length | Length | Length  | Length  |
-|=========================+========+========+=========+=========+
-| dilithium-4x4-r3        | 1312   | 2528   |   64    |    32   |
-| dilithium-4x4-aes-r3    | 1312   | 2528   |   64    |    32   |
-| dilithium-6x5-r3        | 1952   | 4000   |   64    |    32   |
-| dilithium-6x5-aes-r3    | 1952   | 4000   |   64    |    32   |
-| dilithium-8x7-r3        | 2596   | 4864   |   64    |    32   |
-| dilithium-8x7-aes-r3    | 2592   | 4864   |   64    |    32   |
-|=========================+========+========+=========+=========|
+|=========================+========+=========+=========+=========|
+| Algorithm               | Public | Private | Partial | Partial |
+|                         | Key    | Key SK  | SK (V1) | SK (V2) |
+|                         | Length | Length  | Length  | Length  |
+|=========================+========+=========+=========+=========+
+| dilithium-4x4-r3        | 1312   | 2528    |   64    |    32   |
+| dilithium-4x4-aes-r3    | 1312   | 2528    |   64    |    32   |
+| dilithium-6x5-r3        | 1952   | 4000    |   64    |    32   |
+| dilithium-6x5-aes-r3    | 1952   | 4000    |   64    |    32   |
+| dilithium-8x7-r3        | 2592   | 4864    |   64    |    32   |
+| dilithium-8x7-aes-r3    | 2592   | 4864    |   64    |    32   |
+|=========================+========+=========+=========+=========|
 ]]>
                     </artwork>
                 </figure>
 
             </section>
             <section numbered="true" toc="default">
-                <name>Secret Key Full Encoding</name>
+                <name>Private key Full Encoding</name>
                 <t>A Dilithium private key encoded according with PKCS#8 MUST include the following two fields:</t>
                 <ul spacing="compact">
                     <li>dilithium-(kxl)-r3 in the algorithm field of AlgorithmIdentifier</li>
@@ -1332,7 +1333,7 @@ DilithiumPrivateKey ::= SEQUENCE {
     s1          BIT STRING,         -- vector(L)
     s2          BIT STRING,         -- vector(K)
     t0          BIT STRING,
-    PublicKey  [0] IMPLICIT DilithiumPublicKey OPTIONAL
+    publicKey  [0] IMPLICIT DilithiumPublicKey OPTIONAL
                                     -- see next section
 }
 ]]>
@@ -1340,7 +1341,7 @@ DilithiumPrivateKey ::= SEQUENCE {
 
             </section>
             <section numbered="true" toc="default">
-                <name>Secret Key Partial Encoding Option 1</name>
+                <name>Private key Partial Encoding Option 1</name>
 
                 <t>In option 1 of Dilithium partial encoding the rho (nonce) and the seed (key) are used to regenerate the full key.
                     Note: There are a number of alternative ways to encode a partially filled structure that include defining fields as optional and defining fields as 'EMPTY'. As an example partial RSA keys are encoded using EMPTY fields. It can be argued that defining fields as EMPTY significantly simplifies the implementation of parsing ASN.1 frames.
@@ -1356,14 +1357,14 @@ DilithiumPrivateKey ::= SEQUENCE {
     s1          BIT STRING,         -- EMPTY
     s2          BIT STRING,         -- EMPTY
     t0          BIT STRING,         -- EMPTY
-    PublicKey   [0] IMPLICIT DilithiumPublicKey OPTIONAL
+    publicKey   [0] IMPLICIT DilithiumPublicKey OPTIONAL
                                     -- see next section
 }
 ]]>
                 </artwork>
             </section>
             <section numbered="true" toc="default">
-                <name>Secret Key Partial Encoding Option 2</name>
+                <name>Private key Partial Encoding Option 2</name>
 
                 <t>In option 2 of Dilithium partial encoding only zeta (nonce) is used to regenerate the full key.
                     The ASN.1 encoding for this is defined as follows:</t>
@@ -1377,7 +1378,7 @@ DilithiumPrivateKey ::= SEQUENCE {
     s1          BIT STRING,         -- EMPTY
     s2          BIT STRING,         -- EMPTY
     t0          BIT STRING,         -- EMPTY
-    PublicKey   [0] IMPLICIT DilithiumPublicKey OPTIONAL
+    publicKey   [0] IMPLICIT DilithiumPublicKey OPTIONAL
                                    -- see next section
 }
 ]]>
@@ -1418,13 +1419,13 @@ DilithiumPublicKey ::= SEQUENCE {
 | NIST Level Security     | Level 1                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Dimension/Degree n = 512            |
-|                         | Polynomial Phi = 1+X{n}             |
+|                         | Polynomial Phi = 1+x^n              |
 |                         | Modulus q = 12289                   |
 |                         | Max. signature square norm          |
-|                         | floor (beta2) = 34034726            |
+|                         | floor (beta^2) = 34034726           |
 |                         | Standard deviation = 165.736617183  |
-|                         | sigmamax = 1.8205                   |
-|                         | sigmamin = 1.27783369               |
+|                         | sigma_{max} = 1.8205                |
+|                         | sigma_{min} = 1.27783369            |
 |=========================+=====================================|
 | falcon1024-r3                                                 |
 |=========================+=====================================|
@@ -1433,13 +1434,13 @@ DilithiumPublicKey ::= SEQUENCE {
 | NIST Level Security     | Level 5                             |
 |-------------------------|-------------------------------------|
 | Parameters              | Dimension/Degree n = 1024           |
-|                         | Polynomial Phi = 1+X{n}             |
+|                         | Polynomial Phi = 1+x^n              |
 |                         | Modulus q = 12289                   |
 |                         | Max. signature square norm          |
-|                         | floor (beta2) = 34034726            |
+|                         | floor (beta^2) = 34034726           |
 |                         | Standard deviation = 168.388571447  |
-|                         | sigmamax = 1.8205                   |
-|                         | sigmamin = 1.298280334              |
+|                         | sigma_{max} = 1.8205                |
+|                         | sigma_{min} = 1.298280334           |
 |=========================+=====================================|
 ]]>
                     </artwork>
@@ -1449,31 +1450,31 @@ DilithiumPublicKey ::= SEQUENCE {
             </section>
             <section numbered="true" toc="default">
                 <name>Key Details</name>
-                <t>The FALCON secret key contains the key components f, g and F.
-                    Each coefficient of f and g is encoded over a fixed number of bits, which depends on the degree of f and g: 6 bits each for degree 512 (parameter name = falcon512-r3) and 5 bits each for degree 1024 (parameter name = falcon1024-r3). Coefficients of F use 8 bits each, regardless of its degree. Each coefficient uses signed encoding, with two's complement for negative values. Moreover, the minimal value is forbidden, e.g. when using degree 512, the valid range for a coefficient of f or g is ?31 to +31; ?32 is not allowed.</t>
-                <figure anchor="FALCONSecretKeySizes">
+                <t>The FALCON private key contains the key components f, g and F.
+                    Each coefficient of f and g is encoded over a fixed number of bits, which depends on the degree of f and g: 6 bits each for degree 512 (parameter name = falcon512-r3) and 5 bits each for degree 1024 (parameter name = falcon1024-r3). Coefficients of F use 8 bits each, regardless of its degree. Each coefficient uses signed encoding, with two's complement for negative values. Moreover, the minimal value is forbidden, e.g. when using degree 512, the valid range for a coefficient of f or g is -31 to +31; -32 is not allowed.</t>
+                <figure anchor="FALCONPrivateKeySizes">
                     <artwork align="left" name="" type="" alt="">
                         <![CDATA[
-|==========================+=========+==========|
-| Algorithm OID            | Params  |   Secret |
-|                          |         |   Key    |
-|                          |         |   Length |
-|==========================+=========+==========+
-| falcon512-r3             | f=384   | 1280     |
-|                          | g=384   |          |
-|                          | F=512   |          |
-|--------------------------+---------+----------|
-| falcon1024-r3            | f=640   | 2304     |
-|                          | g=640   |          |
-|                          | F=1024  |          |
-|==========================+=========+==========+
+|==========================+=========+===========|
+| Algorithm OID            | Params  |   Private |
+|                          |         |   Key     |
+|                          |         |   Length  |
+|==========================+=========+===========+
+| falcon512-r3             | f=384   | 1280      |
+|                          | g=384   |           |
+|                          | F=512   |           |
+|--------------------------+---------+-----------|
+| falcon1024-r3            | f=640   | 2304      |
+|                          | g=640   |           |
+|                          | F=1024  |           |
+|==========================+=========+===========+
 ]]>
                     </artwork>
                 </figure>
 
             </section>
             <section numbered="true" toc="default">
-                <name>Secret Key Full Encoding</name>
+                <name>Private key Full Encoding</name>
 
                 <t>Encoding a FALCON private key with PKCS#8 must include the following two fields: </t>
                 <ul spacing="compact">
@@ -1488,8 +1489,8 @@ FALCONPrivateKey ::= SEQUENCE {
     version     INTEGER {v2(1)}    -- syntax version 2 (round 3)
     f           OCTET STRING,      -- short integer polynomial f
     g           OCTET STRING,      -- short integer polynomial g
-    F           OCTET STRING,      -- short integer polynomial F
-    PublicKey   [0] IMPLICIT FALCONPublicKey  OPTIONAL
+    f           OCTET STRING,      -- short integer polynomial F
+    publicKey   [0] IMPLICIT FALCONPublicKey  OPTIONAL
                                    -- see next section
 }
 ]]>
@@ -1595,7 +1596,7 @@ FALCONPublicKey := SEQUENCE {
                 </ul>
                 <t>This mapping can be expressed as m quadratic polynomials in the ring F[x1, … , xn], which means the public key consists of m*(n+1)*(n+2)/2 elements of F. With optimizations (see Rainbow specification), this can be reduced to m*n*(n+1)/2 elements of F. The size necessary to hold all public key elements accounts to m*n*(n+1)/16*f bytes, where f=4 for rainbowI and 8 for rainbowIII and rainbowV. For all parameter sets ell is 16 bytes.
                     
-                    Secret key. The secret key consists of 4 parameters:</t>
+                    Private key. The private key consists of 4 parameters:</t>
                 <ul spacing="compact">
                     <li>S: affine map from F^{m} to F^{m}</li>
                     <li>T: affine map from F^{n} to F^{n}</li>
@@ -1618,7 +1619,7 @@ FALCONPublicKey := SEQUENCE {
 
                 <t>The partial public key now consists of 5 submatrices totaling o1*o2*v1 + o1*o1*(o1+1)/2 +o1*o2*o1 + o1*o2*(o2+1)/2 + o2*o2*(o2+1)/2 elements of F. 
                     Additionally the seed spub is 32 bytes.
-                    The secret key can also be stored as the seeds of the key generation process spriv (32 bytes) and spub (32 bytes). 
+                    The private key can also be stored as the seeds of the key generation process spriv (32 bytes) and spub (32 bytes). 
                     This is denoted as the compressed key and has a size of total 64 bytes. 
                     The resulting public key and private key sizes can be found in the table below. </t>
 
@@ -1626,7 +1627,7 @@ FALCONPublicKey := SEQUENCE {
                     <artwork align="left" name="" type="" alt="">
                         <![CDATA[
 |=========================+==========+=========|
-| Algorithm               | Public   | Secret  |
+| Algorithm               | Public   | Private |
 |                         | Key      | Key     |
 |                         | Length   | Length  |
 |=========================+==========+=========+
@@ -1643,7 +1644,7 @@ FALCONPublicKey := SEQUENCE {
 
             </section>
             <section numbered="true" toc="default">
-                <name>Secret Key Full Encoding</name>
+                <name>Private key Full Encoding</name>
 
                 <t>A Rainbow private key encoded according with PKCS#8 MUST include the following two fields: </t>
                 <ul spacing="compact">
@@ -1657,11 +1658,11 @@ FALCONPublicKey := SEQUENCE {
                     <![CDATA[
 RainbowPrivateKey ::= SEQUENCE {
     version    INTEGER {v0(0)}       -- version (round 3)
-    S          OCTET STRING,         -- map S
-    T          OCTET STRING,         -- map T
-    F          OCTET STRING,         -- map F
+    s          OCTET STRING,         -- map S
+    t          OCTET STRING,         -- map T
+    f          OCTET STRING,         -- map F
     ell        OCTET STRING,
-    PublicKey  [0] IMPLICIT RainbowPublicKey OPTIONAL
+    publicKey  [0] IMPLICIT RainbowPublicKey OPTIONAL
     -- see next section
 }
 ]]>
@@ -1669,7 +1670,7 @@ RainbowPrivateKey ::= SEQUENCE {
 
             </section>
             <section numbered="true" toc="default">
-                <name>Secret Key Partial Encoding</name>
+                <name>Private key Partial Encoding</name>
                 <t>A partially populated private key is used when Compressed Rainbow is used. 
                     In this case, spriv and spub are used to regenerate the full key.
                    The ASN.1 encoding is then defined as follows:</t>
@@ -1680,7 +1681,7 @@ RainbowPrivateKey ::= SEQUENCE {
     s_priv     OCTET STRING,    -- seed for private key
     s_pub      OCTET STRING,    -- seed for public key
     ell        OCTET STRING,
-    PublicKey  [0] IMPLICIT RainbowPublicKey OPTIONAL
+    publicKey  [0] IMPLICIT RainbowPublicKey OPTIONAL
                                 -- see next section
 }
 ]]>
@@ -1696,7 +1697,7 @@ RainbowPrivateKey ::= SEQUENCE {
                     <![CDATA[
 RainbowPublicKey ::= SEQUENCE {
     s_pub      OCTET STRING      -- (EMPTY)
-    P          OCTET STRING,
+    p          OCTET STRING,
     ell        OCTET STRING
 }
 ]]>


### PR DESCRIPTION
- Fixed several typos (e.g. occurencies of '?')
- Fixes in ASN1 sytax
- Changed Kyber private key encodings, parameters now have same order as the raw keys.
- Section 2.2 references to RFC5280
- Write "private key" instead of "secret key" consistently
- omit all OIDs (TBD)
- run make

Fixes #1 